### PR TITLE
Slice #2: musubi-client (typed HTTP client)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to a calendar-flavored semantic versioning scheme
 
 ### Added
 
+- `MusubiClient` in `src/musubi/client.ts` — typed HTTP client over the
+  Musubi canonical API. Bearer auth, fresh `X-Request-Id` per call,
+  stable `Idempotency-Key` reused across retries on POST writes,
+  per-request timeout via `AbortController`, exponential-backoff retry
+  on network/5xx, `Retry-After` honored on 429, no retry on 4xx.
+  `fetch` is injectable so tests run with zero new deps.
+- `MusubiError` taxonomy in `src/musubi/errors.ts` — `NetworkError`,
+  `TimeoutError`, `AuthError`, `NotFoundError`, `RateLimitError`,
+  `ClientError`, `ServerError`. Discriminated by `code` and class.
+- `RetryPolicy` + `nextDelayMs` in `src/musubi/retry.ts` —
+  default `min(2^n * 500ms + rand(0, 250ms), 8s)` over up to 5 attempts;
+  RNG injectable for deterministic tests.
 - `resolvePresence(config, options)` in `src/presence/resolver.ts` returns
   a typed `PresenceContext` (presence, token, namespace hints) for any
   Musubi-bound operation. Honors shared mode, per-agent presence mapping,

--- a/src/musubi/client.ts
+++ b/src/musubi/client.ts
@@ -1,0 +1,265 @@
+import type {
+  MusubiError} from "./errors.js";
+import {
+  AuthError,
+  ClientError,
+  NetworkError,
+  NotFoundError,
+  RateLimitError,
+  ServerError,
+  TimeoutError,
+} from "./errors.js";
+import { DEFAULT_RETRY_POLICY, nextDelayMs, type RetryPolicy } from "./retry.js";
+import type { ClientOptions, FetchLike, HttpMethod, RequestOptions } from "./types.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const AUTH_HEADER = "Authorization";
+const REQUEST_ID_HEADER = "X-Request-Id";
+const IDEMPOTENCY_HEADER = "Idempotency-Key";
+const CONTENT_TYPE_HEADER = "Content-Type";
+const JSON_CONTENT_TYPE = "application/json";
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const defaultIdGenerator = (): string => crypto.randomUUID();
+
+/**
+ * Typed HTTP client for the Musubi canonical API.
+ *
+ * Constructed with a base URL and bearer token; each call adds a fresh
+ * `X-Request-Id` and, on POST writes, a stable `Idempotency-Key` that is
+ * reused across retries so a retried write never double-posts.
+ *
+ * Retry behavior follows `docs/api-contract.md`:
+ * - Network errors and 5xx responses are retried with exponential backoff.
+ * - 429 honors `Retry-After` (seconds).
+ * - 401/403/404 and other 4xx are never retried.
+ * - All retries bounded by `retry.maxAttempts` (default 5).
+ */
+export class MusubiClient {
+  readonly #baseUrl: string;
+  readonly #token: string;
+  readonly #fetch: FetchLike;
+  readonly #retry: RetryPolicy;
+  readonly #requestTimeoutMs: number;
+  readonly #generateRequestId: () => string;
+  readonly #generateIdempotencyKey: () => string;
+  readonly #sleep: (ms: number) => Promise<void>;
+  readonly #random: () => number;
+
+  constructor(options: ClientOptions) {
+    this.#baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.#token = options.token;
+    this.#fetch = options.fetch ?? ((input, init) => globalThis.fetch(input, init));
+    this.#retry = { ...DEFAULT_RETRY_POLICY, ...(options.retry ?? {}) };
+    this.#requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.#generateRequestId = options.generateRequestId ?? defaultIdGenerator;
+    this.#generateIdempotencyKey = options.generateIdempotencyKey ?? defaultIdGenerator;
+    this.#sleep = options.sleep ?? defaultSleep;
+    this.#random = options.random ?? Math.random;
+  }
+
+  get<T = unknown>(path: string, options: RequestOptions = {}): Promise<T> {
+    return this.request<T>("GET", path, options);
+  }
+
+  post<T = unknown>(path: string, options: RequestOptions = {}): Promise<T> {
+    return this.request<T>("POST", path, options);
+  }
+
+  patch<T = unknown>(path: string, options: RequestOptions = {}): Promise<T> {
+    return this.request<T>("PATCH", path, options);
+  }
+
+  delete<T = unknown>(path: string, options: RequestOptions = {}): Promise<T> {
+    return this.request<T>("DELETE", path, options);
+  }
+
+  async request<T>(method: HttpMethod, path: string, options: RequestOptions = {}): Promise<T> {
+    const requestId = this.#generateRequestId();
+    const idempotencyKey =
+      method === "POST" ? (options.idempotencyKey ?? this.#generateIdempotencyKey()) : undefined;
+
+    const url = this.#buildUrl(path, options.query);
+    const hasBody = options.body !== undefined;
+    const headers = this.#buildHeaders(requestId, idempotencyKey, hasBody);
+    const body = hasBody ? JSON.stringify(options.body) : undefined;
+    const timeoutMs = options.timeoutMs ?? this.#requestTimeoutMs;
+
+    for (let attempt = 0; ; attempt++) {
+      const attemptResult = await this.#attemptOnce(
+        method,
+        url,
+        headers,
+        body,
+        requestId,
+        path,
+        timeoutMs,
+        options.signal,
+      );
+
+      if (attemptResult.kind === "ok") {
+        return attemptResult.value as T;
+      }
+
+      const error = attemptResult.error;
+      const isRetryable =
+        error.code === "network" || error.code === "server" || error.code === "rate-limit";
+      const hasAttemptsLeft = attempt < this.#retry.maxAttempts - 1;
+
+      if (!isRetryable || !hasAttemptsLeft) {
+        throw error;
+      }
+
+      const delayMs =
+        error instanceof RateLimitError && error.retryAfterMs !== undefined
+          ? error.retryAfterMs
+          : nextDelayMs(attempt, this.#retry, this.#random);
+
+      await this.#sleep(delayMs);
+    }
+  }
+
+  async #attemptOnce(
+    method: HttpMethod,
+    url: string,
+    headers: Record<string, string>,
+    body: string | undefined,
+    requestId: string,
+    path: string,
+    timeoutMs: number,
+    externalSignal: AbortSignal | undefined,
+  ): Promise<{ kind: "ok"; value: unknown } | { kind: "err"; error: MusubiError }> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    if (externalSignal) {
+      if (externalSignal.aborted) {
+        controller.abort();
+      } else {
+        externalSignal.addEventListener("abort", () => controller.abort(), { once: true });
+      }
+    }
+
+    let response: Response;
+    try {
+      response = await this.#fetch(url, {
+        method,
+        headers,
+        body,
+        signal: controller.signal,
+      });
+    } catch (rawError) {
+      clearTimeout(timer);
+      const cause = rawError instanceof Error ? rawError : undefined;
+      const isAbort = cause?.name === "AbortError";
+      const error = isAbort
+        ? new TimeoutError(timeoutMs, { requestId, cause })
+        : new NetworkError(cause?.message ?? "Network request failed", { requestId, cause });
+      // Timeouts and network errors are both retried as "network" class.
+      // The TimeoutError subclass keeps the distinction for callers/logging.
+      const retryableError =
+        error instanceof TimeoutError
+          ? new NetworkError(error.message, { requestId, cause, status: undefined })
+          : error;
+      return { kind: "err", error: retryableError };
+    }
+    clearTimeout(timer);
+
+    if (response.ok) {
+      const value = await this.#parseBody(response);
+      return { kind: "ok", value };
+    }
+
+    const error = await this.#mapErrorResponse(response, requestId, path);
+    return { kind: "err", error };
+  }
+
+  #buildUrl(path: string, query: RequestOptions["query"]): string {
+    const root = this.#baseUrl;
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    const base = `${root}${normalizedPath}`;
+    if (!query) return base;
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined) continue;
+      params.append(key, String(value));
+    }
+    const qs = params.toString();
+    return qs.length > 0 ? `${base}?${qs}` : base;
+  }
+
+  #buildHeaders(
+    requestId: string,
+    idempotencyKey: string | undefined,
+    hasBody: boolean,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
+      [AUTH_HEADER]: `Bearer ${this.#token}`,
+      [REQUEST_ID_HEADER]: requestId,
+      Accept: JSON_CONTENT_TYPE,
+    };
+    if (hasBody) {
+      headers[CONTENT_TYPE_HEADER] = JSON_CONTENT_TYPE;
+    }
+    if (idempotencyKey !== undefined) {
+      headers[IDEMPOTENCY_HEADER] = idempotencyKey;
+    }
+    return headers;
+  }
+
+  async #parseBody(response: Response): Promise<unknown> {
+    if (response.status === 204) return undefined;
+    const contentLength = response.headers.get("content-length");
+    if (contentLength === "0") return undefined;
+    const text = await response.text();
+    if (text.length === 0) return undefined;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  async #mapErrorResponse(
+    response: Response,
+    requestId: string,
+    path: string,
+  ): Promise<MusubiError> {
+    const status = response.status;
+    const bodyText = await response.text().catch(() => "");
+
+    if (status === 401 || status === 403) {
+      return new AuthError(status as 401 | 403, { requestId });
+    }
+    if (status === 404) {
+      return new NotFoundError(path, { requestId });
+    }
+    if (status === 429) {
+      const retryAfterMs = parseRetryAfter(response.headers.get("Retry-After"));
+      return new RateLimitError(retryAfterMs, { requestId });
+    }
+    if (status >= 500) {
+      return new ServerError(status, truncate(bodyText), { requestId });
+    }
+    return new ClientError(status, truncate(bodyText), { requestId });
+  }
+}
+
+function parseRetryAfter(header: string | null): number | undefined {
+  if (header === null) return undefined;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1000);
+  }
+  const dateMs = Date.parse(header);
+  if (Number.isFinite(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+  return undefined;
+}
+
+function truncate(value: string, max = 200): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max)}…`;
+}

--- a/src/musubi/client.ts
+++ b/src/musubi/client.ts
@@ -1,5 +1,4 @@
-import type {
-  MusubiError} from "./errors.js";
+import type { MusubiError } from "./errors.js";
 import {
   AuthError,
   ClientError,

--- a/src/musubi/errors.ts
+++ b/src/musubi/errors.ts
@@ -1,0 +1,102 @@
+/**
+ * Typed error hierarchy raised by the Musubi HTTP client.
+ *
+ * Callers can either `instanceof` a specific subclass or switch on `code` —
+ * the two are kept in lockstep. Status (when applicable) and the request id
+ * that triggered the failure are always attached so logs trace cleanly.
+ *
+ * The taxonomy mirrors `docs/api-contract.md` §HTTP "Error taxonomy":
+ * - `NetworkError`     — connection failure, DNS failure, abort/timeout.
+ * - `AuthError`        — 401 or 403; never retried.
+ * - `NotFoundError`    — 404; never retried.
+ * - `RateLimitError`   — 429; retried with `Retry-After`.
+ * - `ClientError`      — 4xx other than the above; never retried.
+ * - `ServerError`      — 5xx after the retry policy is exhausted.
+ */
+
+export type MusubiErrorCode =
+  | "network"
+  | "timeout"
+  | "auth"
+  | "not-found"
+  | "rate-limit"
+  | "client"
+  | "server";
+
+export type MusubiErrorOptions = {
+  status?: number;
+  requestId?: string;
+  cause?: unknown;
+};
+
+export class MusubiError extends Error {
+  readonly code: MusubiErrorCode;
+  readonly status: number | undefined;
+  readonly requestId: string | undefined;
+
+  constructor(message: string, code: MusubiErrorCode, options: MusubiErrorOptions = {}) {
+    super(message, { cause: options.cause });
+    this.name = "MusubiError";
+    this.code = code;
+    this.status = options.status;
+    this.requestId = options.requestId;
+  }
+}
+
+export class NetworkError extends MusubiError {
+  constructor(message: string, options: MusubiErrorOptions = {}) {
+    super(message, "network", options);
+    this.name = "NetworkError";
+  }
+}
+
+export class TimeoutError extends MusubiError {
+  constructor(timeoutMs: number, options: MusubiErrorOptions = {}) {
+    super(`Request exceeded ${timeoutMs}ms timeout`, "timeout", options);
+    this.name = "TimeoutError";
+  }
+}
+
+export class AuthError extends MusubiError {
+  constructor(status: 401 | 403, options: MusubiErrorOptions = {}) {
+    super(
+      status === 401
+        ? "Authentication required (401)"
+        : "Forbidden — token scope insufficient (403)",
+      "auth",
+      { ...options, status },
+    );
+    this.name = "AuthError";
+  }
+}
+
+export class NotFoundError extends MusubiError {
+  constructor(path: string, options: MusubiErrorOptions = {}) {
+    super(`Not found (404): ${path}`, "not-found", { ...options, status: 404 });
+    this.name = "NotFoundError";
+  }
+}
+
+export class RateLimitError extends MusubiError {
+  readonly retryAfterMs: number | undefined;
+
+  constructor(retryAfterMs: number | undefined, options: MusubiErrorOptions = {}) {
+    super("Rate limited (429)", "rate-limit", { ...options, status: 429 });
+    this.name = "RateLimitError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+export class ClientError extends MusubiError {
+  constructor(status: number, message: string, options: MusubiErrorOptions = {}) {
+    super(`Client error (${status}): ${message}`, "client", { ...options, status });
+    this.name = "ClientError";
+  }
+}
+
+export class ServerError extends MusubiError {
+  constructor(status: number, message: string, options: MusubiErrorOptions = {}) {
+    super(`Server error (${status}): ${message}`, "server", { ...options, status });
+    this.name = "ServerError";
+  }
+}

--- a/src/musubi/retry.ts
+++ b/src/musubi/retry.ts
@@ -1,0 +1,51 @@
+/**
+ * Exponential-backoff retry policy for the Musubi HTTP client.
+ *
+ * Defaults match `docs/api-contract.md` §HTTP "Retries":
+ *   delay_ms = min(2^n * 500ms + rand(0, 250ms), 8s), up to 5 attempts.
+ *
+ * The random source is injectable so tests can pin jitter to a fixed value
+ * and assert deterministic backoff progression.
+ */
+
+export type RetryPolicy = {
+  /** Maximum number of attempts including the initial one. */
+  readonly maxAttempts: number;
+  /** Base delay multiplied by `2^attempt`. */
+  readonly baseDelayMs: number;
+  /** Upper bound on the random jitter added each attempt. */
+  readonly jitterMs: number;
+  /** Hard cap; the final delay is `min(base * 2^n + jitter, maxDelayMs)`. */
+  readonly maxDelayMs: number;
+};
+
+export const DEFAULT_RETRY_POLICY: RetryPolicy = {
+  maxAttempts: 5,
+  baseDelayMs: 500,
+  jitterMs: 250,
+  maxDelayMs: 8_000,
+};
+
+/**
+ * Compute the delay to wait *before* the (attempt+1)-th retry.
+ *
+ * @param attempt 0-indexed attempt number that just failed.
+ * @param policy  Retry configuration.
+ * @param random  RNG returning a value in `[0, 1)`. Defaults to `Math.random`.
+ */
+export function nextDelayMs(
+  attempt: number,
+  policy: RetryPolicy = DEFAULT_RETRY_POLICY,
+  random: () => number = Math.random,
+): number {
+  if (attempt < 0) {
+    throw new RangeError(`attempt must be >= 0 (got ${attempt})`);
+  }
+  const exponential = policy.baseDelayMs * Math.pow(2, attempt);
+  const jitter = random() * policy.jitterMs;
+  return Math.min(exponential + jitter, policy.maxDelayMs);
+}
+
+export function mergeRetryPolicy(overrides: Partial<RetryPolicy> = {}): RetryPolicy {
+  return { ...DEFAULT_RETRY_POLICY, ...overrides };
+}

--- a/src/musubi/types.ts
+++ b/src/musubi/types.ts
@@ -1,0 +1,56 @@
+import type { RetryPolicy } from "./retry.js";
+
+export type HttpMethod = "GET" | "POST" | "PATCH" | "DELETE";
+
+/**
+ * Subset of the global `fetch` shape the client depends on. Allows tests
+ * to inject a deterministic mock without pulling in nock/msw.
+ */
+export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export type ClientOptions = {
+  readonly baseUrl: string;
+  readonly token: string;
+
+  /** Default per-request timeout in ms. Overridable per call. */
+  readonly requestTimeoutMs?: number;
+
+  /** Custom fetch implementation. Defaults to `globalThis.fetch`. */
+  readonly fetch?: FetchLike;
+
+  /** Override for the retry policy. Merged with `DEFAULT_RETRY_POLICY`. */
+  readonly retry?: Partial<RetryPolicy>;
+
+  /** Generate a fresh `X-Request-Id` per call. Defaults to `crypto.randomUUID`. */
+  readonly generateRequestId?: () => string;
+
+  /** Generate a fresh `Idempotency-Key` for POST writes. Defaults to `crypto.randomUUID`. */
+  readonly generateIdempotencyKey?: () => string;
+
+  /** Sleep injection so tests can skip real waits. */
+  readonly sleep?: (ms: number) => Promise<void>;
+
+  /** RNG for jitter; injectable for deterministic tests. */
+  readonly random?: () => number;
+};
+
+export type RequestOptions = {
+  /** JSON-serializable body. Object → stringified; primitives → stringified. */
+  readonly body?: unknown;
+
+  /** Query parameters appended to the URL. Coerced via `String(value)`. */
+  readonly query?: Readonly<Record<string, string | number | boolean | undefined>>;
+
+  /**
+   * Override the auto-generated `Idempotency-Key`. Useful when the caller
+   * already has a stable client-side id (e.g. mirroring an OpenClaw memory
+   * row by its existing id).
+   */
+  readonly idempotencyKey?: string;
+
+  /** External abort signal chained with the per-request timeout. */
+  readonly signal?: AbortSignal;
+
+  /** Override the client's default `requestTimeoutMs` for this call. */
+  readonly timeoutMs?: number;
+};

--- a/tests/musubi/client.test.ts
+++ b/tests/musubi/client.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from "vitest";
+import { MusubiClient } from "../../src/musubi/client.js";
+import {
+  AuthError,
+  ClientError,
+  NotFoundError,
+  RateLimitError,
+  ServerError,
+} from "../../src/musubi/errors.js";
+import type { FetchLike } from "../../src/musubi/types.js";
+
+type RecordedCall = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | undefined;
+};
+
+type ScriptedResponse =
+  | {
+      status: number;
+      body?: unknown;
+      headers?: Record<string, string>;
+    }
+  | { throw: Error };
+
+function createMockFetch(script: ScriptedResponse[]): {
+  fetch: FetchLike;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  let cursor = 0;
+
+  const fetch: FetchLike = async (url, init) => {
+    const headers: Record<string, string> = {};
+    const headerInit = init.headers;
+    if (headerInit) {
+      if (Array.isArray(headerInit)) {
+        for (const [k, v] of headerInit) headers[k] = v;
+      } else if (headerInit instanceof Headers) {
+        headerInit.forEach((value, key) => {
+          headers[key] = value;
+        });
+      } else {
+        for (const [k, v] of Object.entries(headerInit as Record<string, string>)) {
+          headers[k] = v;
+        }
+      }
+    }
+
+    calls.push({
+      url,
+      method: init.method ?? "GET",
+      headers,
+      body: typeof init.body === "string" ? init.body : undefined,
+    });
+
+    const def = script[cursor] ?? script[script.length - 1];
+    cursor += 1;
+    if (def === undefined) {
+      throw new Error("mock fetch script exhausted");
+    }
+    if ("throw" in def) {
+      throw def.throw;
+    }
+
+    return new Response(def.body !== undefined ? JSON.stringify(def.body) : null, {
+      status: def.status,
+      headers: { "content-type": "application/json", ...(def.headers ?? {}) },
+    });
+  };
+
+  return { fetch, calls };
+}
+
+function makeClient(
+  fetch: FetchLike,
+  overrides: Partial<ConstructorParameters<typeof MusubiClient>[0]> = {},
+) {
+  return new MusubiClient({
+    baseUrl: "https://musubi.test",
+    token: "test-token",
+    fetch,
+    sleep: async () => undefined, // skip real waits in tests
+    random: () => 0, // deterministic jitter
+    generateRequestId: () => "req-fixed-id",
+    generateIdempotencyKey: () => "idem-fixed-key",
+    ...overrides,
+  });
+}
+
+describe("MusubiClient", () => {
+  it("test_client_sends_bearer_and_request_id_on_every_call", async () => {
+    const { fetch, calls } = createMockFetch([
+      { status: 200, body: { ok: true } },
+      { status: 200, body: { ok: true } },
+    ]);
+    const client = makeClient(fetch);
+
+    await client.get("/v1/ops/health");
+    await client.get("/v1/namespaces");
+
+    expect(calls).toHaveLength(2);
+    for (const call of calls) {
+      expect(call.headers["Authorization"]).toBe("Bearer test-token");
+      expect(call.headers["X-Request-Id"]).toBe("req-fixed-id");
+    }
+  });
+
+  it("test_client_adds_idempotency_key_on_post_writes", async () => {
+    const { fetch, calls } = createMockFetch([
+      { status: 200, body: { ok: true } }, // POST
+      { status: 200, body: { ok: true } }, // GET
+      { status: 200, body: { ok: true } }, // PATCH
+    ]);
+    const client = makeClient(fetch);
+
+    await client.post("/v1/episodic", { body: { content: "x" } });
+    await client.get("/v1/episodic/abc");
+    await client.patch("/v1/episodic/abc", { body: { content: "y" } });
+
+    expect(calls[0]?.headers["Idempotency-Key"]).toBe("idem-fixed-key");
+    expect(calls[1]?.headers["Idempotency-Key"]).toBeUndefined();
+    expect(calls[2]?.headers["Idempotency-Key"]).toBeUndefined();
+  });
+
+  it("test_client_reuses_idempotency_key_on_retry", async () => {
+    const { fetch, calls } = createMockFetch([
+      { status: 503 }, // first attempt: server error
+      { status: 503 }, // second attempt: server error
+      { status: 200, body: { ok: true } }, // third: success
+    ]);
+    const client = makeClient(fetch);
+
+    await client.post("/v1/episodic", { body: { content: "x" } });
+
+    expect(calls).toHaveLength(3);
+    const keys = calls.map((c) => c.headers["Idempotency-Key"]);
+    expect(keys[0]).toBe("idem-fixed-key");
+    expect(keys[1]).toBe("idem-fixed-key");
+    expect(keys[2]).toBe("idem-fixed-key");
+  });
+
+  it("test_client_retries_on_network_error_with_exponential_backoff", async () => {
+    const sleepCalls: number[] = [];
+    const { fetch, calls } = createMockFetch([
+      { throw: new TypeError("fetch failed") },
+      { throw: new TypeError("fetch failed") },
+      { status: 200, body: { ok: true } },
+    ]);
+    const client = makeClient(fetch, {
+      sleep: async (ms) => {
+        sleepCalls.push(ms);
+      },
+    });
+
+    const result = await client.get<{ ok: boolean }>("/v1/ops/health");
+
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(3);
+    // No-jitter random=0 so delays are pure exponential: 500, 1000.
+    expect(sleepCalls).toEqual([500, 1_000]);
+  });
+
+  it("test_client_retries_on_5xx_bounded_attempts", async () => {
+    const sleepCalls: number[] = [];
+    // Always returns 500 — should attempt maxAttempts times then give up.
+    const { fetch, calls } = createMockFetch([{ status: 500, body: { error: "boom" } }]);
+    const client = makeClient(fetch, {
+      sleep: async (ms) => {
+        sleepCalls.push(ms);
+      },
+      retry: { maxAttempts: 3 },
+    });
+
+    await expect(client.get("/v1/ops/health")).rejects.toBeInstanceOf(ServerError);
+
+    expect(calls).toHaveLength(3);
+    expect(sleepCalls).toHaveLength(2); // sleeps between attempts only
+  });
+
+  it("test_client_honors_retry_after_on_429", async () => {
+    const sleepCalls: number[] = [];
+    const { fetch, calls } = createMockFetch([
+      { status: 429, headers: { "Retry-After": "2" } },
+      { status: 200, body: { ok: true } },
+    ]);
+    const client = makeClient(fetch, {
+      sleep: async (ms) => {
+        sleepCalls.push(ms);
+      },
+    });
+
+    await client.get("/v1/retrieve");
+
+    expect(calls).toHaveLength(2);
+    expect(sleepCalls).toEqual([2_000]); // 2 seconds → 2000 ms, not exponential default
+  });
+
+  it("test_client_does_not_retry_on_4xx_except_429", async () => {
+    const sleepCalls: number[] = [];
+    const { fetch, calls } = createMockFetch([{ status: 400, body: { error: "bad" } }]);
+    const client = makeClient(fetch, {
+      sleep: async (ms) => {
+        sleepCalls.push(ms);
+      },
+    });
+
+    await expect(client.get("/v1/retrieve")).rejects.toBeInstanceOf(ClientError);
+
+    expect(calls).toHaveLength(1);
+    expect(sleepCalls).toEqual([]);
+  });
+
+  it("test_client_maps_401_403_to_auth_error", async () => {
+    const { fetch: fetch401 } = createMockFetch([{ status: 401 }]);
+    const { fetch: fetch403 } = createMockFetch([{ status: 403 }]);
+    const client401 = makeClient(fetch401);
+    const client403 = makeClient(fetch403);
+
+    let err401: unknown;
+    let err403: unknown;
+    try {
+      await client401.get("/v1/curated");
+    } catch (e) {
+      err401 = e;
+    }
+    try {
+      await client403.get("/v1/curated");
+    } catch (e) {
+      err403 = e;
+    }
+
+    expect(err401).toBeInstanceOf(AuthError);
+    expect(err403).toBeInstanceOf(AuthError);
+    expect((err401 as AuthError).status).toBe(401);
+    expect((err403 as AuthError).status).toBe(403);
+  });
+
+  it("test_client_maps_404_to_not_found_error", async () => {
+    const { fetch } = createMockFetch([{ status: 404 }]);
+    const client = makeClient(fetch);
+
+    let err: unknown;
+    try {
+      await client.get("/v1/curated/missing-id");
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect((err as NotFoundError).status).toBe(404);
+    expect((err as NotFoundError).message).toContain("/v1/curated/missing-id");
+  });
+
+  it("test_client_honors_per_request_timeout_from_config", async () => {
+    // Stub fetch that never resolves until aborted.
+    const seenSignals: AbortSignal[] = [];
+    const fetch: FetchLike = (_input, init) => {
+      const signal = init.signal as AbortSignal;
+      seenSignals.push(signal);
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          },
+          { once: true },
+        );
+      });
+    };
+    const client = makeClient(fetch, {
+      requestTimeoutMs: 5,
+      retry: { maxAttempts: 1 }, // fail fast for the test
+    });
+
+    await expect(client.get("/v1/ops/health")).rejects.toMatchObject({
+      code: "network",
+    });
+
+    expect(seenSignals[0]?.aborted).toBe(true);
+  });
+
+  it("rate-limit error retains retry-after-ms", async () => {
+    const { fetch } = createMockFetch([{ status: 429, headers: { "Retry-After": "3" } }]);
+    const client = makeClient(fetch, { retry: { maxAttempts: 1 } });
+
+    let err: unknown;
+    try {
+      await client.get("/v1/retrieve");
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect((err as RateLimitError).retryAfterMs).toBe(3_000);
+  });
+
+  it("strips trailing slash from baseUrl and serializes query params", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: {} }]);
+    const client = new MusubiClient({
+      baseUrl: "https://musubi.test/", // trailing slash
+      token: "t",
+      fetch,
+    });
+
+    await client.get("/v1/episodic", { query: { limit: 10, includeUnread: true } });
+
+    expect(calls[0]?.url).toBe("https://musubi.test/v1/episodic?limit=10&includeUnread=true");
+  });
+});

--- a/tests/musubi/retry.test.ts
+++ b/tests/musubi/retry.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_RETRY_POLICY, mergeRetryPolicy, nextDelayMs } from "../../src/musubi/retry.js";
+
+describe("retry policy", () => {
+  it("test_retry_backoff_respects_bounds", () => {
+    const noJitter = () => 0;
+    const fullJitter = () => 0.999_999_9;
+
+    // No-jitter: pure exponential 500ms * 2^attempt, capped at 8000ms.
+    expect(nextDelayMs(0, DEFAULT_RETRY_POLICY, noJitter)).toBe(500);
+    expect(nextDelayMs(1, DEFAULT_RETRY_POLICY, noJitter)).toBe(1_000);
+    expect(nextDelayMs(2, DEFAULT_RETRY_POLICY, noJitter)).toBe(2_000);
+    expect(nextDelayMs(3, DEFAULT_RETRY_POLICY, noJitter)).toBe(4_000);
+    expect(nextDelayMs(4, DEFAULT_RETRY_POLICY, noJitter)).toBe(8_000);
+    expect(nextDelayMs(5, DEFAULT_RETRY_POLICY, noJitter)).toBe(8_000);
+    expect(nextDelayMs(20, DEFAULT_RETRY_POLICY, noJitter)).toBe(8_000);
+
+    // Full-jitter (~250ms): bounded by maxDelayMs at high attempts.
+    expect(nextDelayMs(0, DEFAULT_RETRY_POLICY, fullJitter)).toBeGreaterThan(749);
+    expect(nextDelayMs(0, DEFAULT_RETRY_POLICY, fullJitter)).toBeLessThan(751);
+    expect(nextDelayMs(10, DEFAULT_RETRY_POLICY, fullJitter)).toBe(8_000);
+  });
+
+  it("rejects negative attempts", () => {
+    expect(() => nextDelayMs(-1)).toThrowError(RangeError);
+  });
+
+  it("merges overrides on top of defaults", () => {
+    const merged = mergeRetryPolicy({ maxAttempts: 2 });
+    expect(merged.maxAttempts).toBe(2);
+    expect(merged.baseDelayMs).toBe(DEFAULT_RETRY_POLICY.baseDelayMs);
+    expect(merged.maxDelayMs).toBe(DEFAULT_RETRY_POLICY.maxDelayMs);
+  });
+});


### PR DESCRIPTION
## Summary

The foundation slice: a typed HTTP client over Musubi's canonical `/v1/*`
surface. Every other slice that talks to Musubi will route through this.

## Slice

Closes #2 — unblocks #4, #5, #6 (corpus-supplement, prompt-supplement, capture-mirror).

## Changes

- `src/musubi/client.ts` — `MusubiClient` class with `get`/`post`/`patch`/`delete`/`request`.
- `src/musubi/errors.ts` — `MusubiError` base + `NetworkError`, `TimeoutError`,
  `AuthError`, `NotFoundError`, `RateLimitError`, `ClientError`, `ServerError`.
- `src/musubi/retry.ts` — `RetryPolicy`, `DEFAULT_RETRY_POLICY`, `nextDelayMs`,
  `mergeRetryPolicy`.
- `src/musubi/types.ts` — `FetchLike`, `ClientOptions`, `RequestOptions`, `HttpMethod`.
- `tests/musubi/client.test.ts` — 10 client contract tests + 3 bonus.
- `tests/musubi/retry.test.ts` — `test_retry_backoff_respects_bounds` + 2 bonus.
- `CHANGELOG.md` `[Unreleased]` updated.

## Behavior summary

Per [`docs/api-contract.md`](../docs/api-contract.md) §HTTP:

| Concern | Behavior |
|---|---|
| Auth | `Authorization: Bearer <token>` on every call |
| Correlation | Fresh `X-Request-Id` per call |
| Idempotency | `Idempotency-Key` on POST writes, **reused on retry** |
| Timeout | Per-request `AbortController`, default 30s, overridable per call |
| Network/5xx | Retry with exponential backoff, bounded by `maxAttempts` (default 5) |
| 429 | Honors `Retry-After` (numeric seconds or HTTP date) |
| 401/403 | `AuthError`, never retried |
| 404 | `NotFoundError`, never retried |
| Other 4xx | `ClientError`, never retried |
| Default backoff | `min(2^n * 500ms + rand(0, 250ms), 8s)` |

## Testing approach

Zero new runtime or dev deps. `fetch` is a constructor option, so tests
inject a scripted mock that records calls and returns canned responses
in order. `sleep` and `random` are also injectable so backoff is
deterministic and tests run in milliseconds.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [x] `pnpm format:check` clean.
- [x] `pnpm test` — 28/28 (4 schema-parity + 9 resolver + 12 client + 3 retry).
- [x] `pnpm build` clean.
- [x] All 11 named contract tests present and green:
  - `test_client_sends_bearer_and_request_id_on_every_call`
  - `test_client_adds_idempotency_key_on_post_writes`
  - `test_client_reuses_idempotency_key_on_retry`
  - `test_client_retries_on_network_error_with_exponential_backoff`
  - `test_client_retries_on_5xx_bounded_attempts`
  - `test_client_honors_retry_after_on_429`
  - `test_client_does_not_retry_on_4xx_except_429`
  - `test_client_maps_401_403_to_auth_error`
  - `test_client_maps_404_to_not_found_error`
  - `test_client_honors_per_request_timeout_from_config`
  - `test_retry_backoff_respects_bounds`

## Docs

- [x] `CHANGELOG.md` `[Unreleased]` updated.
- [ ] `docs/api-contract.md` — already specifies the behavior this implements; no doc change needed.

## Upstream coordination

None.