### PR TITLE
Slice #4: corpus-supplement (MemoryCorpusSupplement)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to a calendar-flavored semantic versioning scheme
 
 ### Added
 
+- `createCorpusSupplement({ client, config })` in `src/supplement/corpus.ts`
+  returns an OpenClaw `MemoryCorpusSupplement`-shaped object. `search`
+  POSTs `/v1/retrieve` in fast mode with configured planes (default
+  `[curated, concept]`) and per-presence namespace; `get` fetches by
+  `<plane>/<id>` lookup path. Failures swallowed → empty results so
+  OpenClaw memory search never breaks. Provenance labels per plane
+  let the model weigh curated > concept > episodic naturally.
 - `MusubiClient` in `src/musubi/client.ts` — typed HTTP client over the
   Musubi canonical API. Bearer auth, fresh `X-Request-Id` per call,
   stable `Idempotency-Key` reused across retries on POST writes,

--- a/src/supplement/corpus.ts
+++ b/src/supplement/corpus.ts
@@ -1,0 +1,211 @@
+import {
+  DEFAULT_SUPPLEMENT_MAX_RESULTS,
+  DEFAULT_SUPPLEMENT_PLANES,
+  type MusubiConfig,
+} from "../config.js";
+import type { MusubiClient } from "../musubi/client.js";
+import { resolvePresence } from "../presence/resolver.js";
+
+/**
+ * Structural shape of a single result row consumed by OpenClaw's
+ * `MemoryCorpusSupplement.search` callback. Mirrors `MemoryCorpusSearchResult`
+ * in the OpenClaw SDK (`src/plugins/memory-state.ts`) — duplicated here so
+ * this slice does not depend on a specific SDK version's type re-exports.
+ * The integration slice that wires this into a `definePluginEntry` callback
+ * will assert structural compatibility.
+ */
+export type CorpusSearchResult = {
+  readonly corpus: string;
+  readonly path: string;
+  readonly score: number;
+  readonly snippet: string;
+  readonly title?: string;
+  readonly kind?: string;
+  readonly id?: string;
+  readonly source?: string;
+  readonly provenanceLabel?: string;
+};
+
+export type CorpusGetResult = {
+  readonly corpus: string;
+  readonly path: string;
+  readonly title?: string;
+  readonly kind?: string;
+  readonly content: string;
+  readonly fromLine: number;
+  readonly lineCount: number;
+};
+
+export type CorpusSupplement = {
+  readonly enabled: boolean;
+  search(params: {
+    query: string;
+    maxResults?: number;
+    agentSessionKey?: string;
+  }): Promise<CorpusSearchResult[]>;
+  get(params: {
+    lookup: string;
+    fromLine?: number;
+    lineCount?: number;
+    agentSessionKey?: string;
+  }): Promise<CorpusGetResult | null>;
+};
+
+export type CreateCorpusSupplementOptions = {
+  readonly client: MusubiClient;
+  readonly config: MusubiConfig;
+};
+
+export const CORPUS_NAME = "musubi";
+
+type MusubiRetrieveRow = {
+  readonly object_id: string;
+  readonly score: number;
+  readonly plane: string;
+  readonly content: string;
+  readonly namespace: string;
+  readonly extra?: Record<string, unknown>;
+};
+
+type MusubiRetrieveResponse = {
+  readonly results: readonly MusubiRetrieveRow[];
+  readonly mode: string;
+  readonly limit: number;
+};
+
+type MusubiObjectFetchResponse = {
+  readonly object_id?: string;
+  readonly content?: string;
+  readonly title?: string;
+  readonly namespace?: string;
+};
+
+const SNIPPET_MAX_CHARS = 280;
+
+/**
+ * Build a `MemoryCorpusSupplement`-shaped object that reads from Musubi's
+ * `/v1/retrieve` (search) and `/v1/curated/{id}` / `/v1/concepts/{id}` (get).
+ *
+ * The supplement is **non-blocking** for OpenClaw's memory search: any error
+ * reaching Musubi (network, auth, server) returns an empty result set rather
+ * than failing the search, so users always get *something* even if Musubi
+ * is temporarily unreachable.
+ */
+export function createCorpusSupplement(options: CreateCorpusSupplementOptions): CorpusSupplement {
+  const { client, config } = options;
+  const supplementCfg = config.supplement ?? {};
+  const enabled = supplementCfg.enabled !== false;
+  const planes =
+    supplementCfg.planes && supplementCfg.planes.length > 0
+      ? [...supplementCfg.planes]
+      : [...DEFAULT_SUPPLEMENT_PLANES];
+  const cap = supplementCfg.maxResults ?? DEFAULT_SUPPLEMENT_MAX_RESULTS;
+
+  return {
+    enabled,
+
+    async search(params) {
+      if (!enabled) return [];
+
+      let presence;
+      try {
+        presence = resolvePresence(config, { agentId: params.agentSessionKey });
+      } catch {
+        return [];
+      }
+
+      const limit = Math.max(1, Math.min(params.maxResults ?? cap, cap));
+
+      try {
+        const response = await client.post<MusubiRetrieveResponse>("/v1/retrieve", {
+          body: {
+            query_text: params.query,
+            mode: "fast",
+            planes,
+            limit,
+            namespace: presence.presence,
+          },
+        });
+        return (response.results ?? []).map(toCorpusSearchResult);
+      } catch {
+        return [];
+      }
+    },
+
+    async get(params) {
+      if (!enabled) return null;
+
+      const [plane, id] = splitLookup(params.lookup);
+      if (plane === undefined || id === undefined) return null;
+
+      try {
+        resolvePresence(config, { agentId: params.agentSessionKey });
+      } catch {
+        return null;
+      }
+
+      const path = endpointForPlane(plane, id);
+      if (path === undefined) return null;
+
+      try {
+        const obj = await client.get<MusubiObjectFetchResponse>(path);
+        return toCorpusGetResult(obj, plane, params.lookup);
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+function splitLookup(lookup: string): [string?, string?] {
+  const idx = lookup.indexOf("/");
+  if (idx <= 0 || idx === lookup.length - 1) return [];
+  return [lookup.slice(0, idx), lookup.slice(idx + 1)];
+}
+
+function endpointForPlane(plane: string, id: string): string | undefined {
+  const safeId = encodeURIComponent(id);
+  if (plane === "curated") return `/v1/curated/${safeId}`;
+  if (plane === "concept") return `/v1/concepts/${safeId}`;
+  if (plane === "episodic") return `/v1/episodic/${safeId}`;
+  if (plane === "artifact") return `/v1/artifacts/${safeId}`;
+  return undefined;
+}
+
+function toCorpusSearchResult(row: MusubiRetrieveRow): CorpusSearchResult {
+  return {
+    corpus: CORPUS_NAME,
+    path: `${row.plane}/${row.object_id}`,
+    score: row.score,
+    snippet: row.content.slice(0, SNIPPET_MAX_CHARS),
+    id: row.object_id,
+    source: row.namespace,
+    provenanceLabel: provenanceLabelFor(row.plane),
+    kind: row.plane,
+  };
+}
+
+function provenanceLabelFor(plane: string): string {
+  if (plane === "curated") return "Curated knowledge (high provenance)";
+  if (plane === "concept") return "Synthesized concept (system hypothesis)";
+  if (plane === "episodic") return "Recent episodic memory";
+  if (plane === "artifact") return "Source artifact";
+  return plane;
+}
+
+function toCorpusGetResult(
+  obj: MusubiObjectFetchResponse,
+  plane: string,
+  lookup: string,
+): CorpusGetResult {
+  const content = obj.content ?? "";
+  return {
+    corpus: CORPUS_NAME,
+    path: lookup,
+    title: obj.title,
+    kind: plane,
+    content,
+    fromLine: 0,
+    lineCount: content.split("\n").length,
+  };
+}

--- a/tests/supplement/corpus.test.ts
+++ b/tests/supplement/corpus.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from "vitest";
+import { MusubiClient } from "../../src/musubi/client.js";
+import { createCorpusSupplement, type CorpusSearchResult } from "../../src/supplement/corpus.js";
+import type { MusubiConfig } from "../../src/config.js";
+import type { FetchLike } from "../../src/musubi/types.js";
+
+type RecordedCall = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | undefined;
+};
+
+type ScriptedResponse =
+  | { status: number; body?: unknown; headers?: Record<string, string> }
+  | { throw: Error };
+
+function createMockFetch(script: ScriptedResponse[]): {
+  fetch: FetchLike;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  let cursor = 0;
+  const fetch: FetchLike = async (url, init) => {
+    const headers: Record<string, string> = {};
+    const headerInit = init.headers;
+    if (headerInit) {
+      if (headerInit instanceof Headers) {
+        headerInit.forEach((value, key) => {
+          headers[key] = value;
+        });
+      } else if (Array.isArray(headerInit)) {
+        for (const [k, v] of headerInit) headers[k] = v;
+      } else {
+        for (const [k, v] of Object.entries(headerInit as Record<string, string>)) {
+          headers[k] = v;
+        }
+      }
+    }
+    calls.push({
+      url,
+      method: init.method ?? "GET",
+      headers,
+      body: typeof init.body === "string" ? init.body : undefined,
+    });
+    const def = script[cursor] ?? script[script.length - 1];
+    cursor += 1;
+    if (def === undefined) throw new Error("mock fetch script exhausted");
+    if ("throw" in def) throw def.throw;
+    return new Response(def.body !== undefined ? JSON.stringify(def.body) : null, {
+      status: def.status,
+      headers: { "content-type": "application/json", ...(def.headers ?? {}) },
+    });
+  };
+  return { fetch, calls };
+}
+
+function makeConfig(overrides: Partial<MusubiConfig> = {}): MusubiConfig {
+  return {
+    core: {
+      baseUrl: "https://musubi.test",
+      token: "test-token",
+      ...(overrides.core ?? {}),
+    },
+    presence: {
+      defaultId: "eric/openclaw",
+      ...(overrides.presence ?? {}),
+    },
+    ...(overrides.supplement !== undefined ? { supplement: overrides.supplement } : {}),
+    ...(overrides.capture !== undefined ? { capture: overrides.capture } : {}),
+    ...(overrides.thoughts !== undefined ? { thoughts: overrides.thoughts } : {}),
+  };
+}
+
+function makeClient(fetch: FetchLike) {
+  return new MusubiClient({
+    baseUrl: "https://musubi.test",
+    token: "test-token",
+    fetch,
+    sleep: async () => undefined,
+    random: () => 0,
+    generateRequestId: () => "req-id",
+    generateIdempotencyKey: () => "idem-key",
+    retry: { maxAttempts: 1 },
+  });
+}
+
+const SAMPLE_RETRIEVE_RESPONSE = {
+  results: [
+    {
+      object_id: "ksuid-cur-1",
+      score: 0.95,
+      plane: "curated",
+      content: "Eric prefers TypeScript over JavaScript for new projects.",
+      namespace: "eric/_shared/curated",
+    },
+    {
+      object_id: "ksuid-con-1",
+      score: 0.83,
+      plane: "concept",
+      content: "Cross-modality memory continuity emerges as a recurring theme.",
+      namespace: "eric/_shared/concept",
+    },
+  ],
+  mode: "fast",
+  limit: 5,
+};
+
+describe("createCorpusSupplement", () => {
+  it("test_supplement_queries_retrieve_with_fast_mode", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: SAMPLE_RETRIEVE_RESPONSE }]);
+    const supplement = createCorpusSupplement({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    await supplement.search({ query: "what does eric prefer?" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("https://musubi.test/v1/retrieve");
+    expect(calls[0]?.method).toBe("POST");
+    const body = JSON.parse(calls[0]!.body!);
+    expect(body.mode).toBe("fast");
+    expect(body.query_text).toBe("what does eric prefer?");
+  });
+
+  it("test_supplement_filters_to_configured_planes", async () => {
+    const { fetch, calls } = createMockFetch([
+      { status: 200, body: { results: [], mode: "fast", limit: 5 } },
+      { status: 200, body: { results: [], mode: "fast", limit: 5 } },
+    ]);
+    const client = makeClient(fetch);
+
+    const defaultSupplement = createCorpusSupplement({ client, config: makeConfig() });
+    await defaultSupplement.search({ query: "x" });
+    const defaultBody = JSON.parse(calls[0]!.body!);
+    expect(defaultBody.planes).toEqual(["curated", "concept"]);
+
+    const customSupplement = createCorpusSupplement({
+      client,
+      config: makeConfig({ supplement: { planes: ["curated"] } }),
+    });
+    await customSupplement.search({ query: "x" });
+    const customBody = JSON.parse(calls[1]!.body!);
+    expect(customBody.planes).toEqual(["curated"]);
+  });
+
+  it("test_supplement_respects_max_results_cap", async () => {
+    const { fetch, calls } = createMockFetch([
+      { status: 200, body: { results: [], mode: "fast", limit: 3 } },
+      { status: 200, body: { results: [], mode: "fast", limit: 3 } },
+    ]);
+    const supplement = createCorpusSupplement({
+      client: makeClient(fetch),
+      config: makeConfig({ supplement: { maxResults: 3 } }),
+    });
+
+    // Caller passes a higher limit; cap wins.
+    await supplement.search({ query: "x", maxResults: 50 });
+    expect(JSON.parse(calls[0]!.body!).limit).toBe(3);
+
+    // Caller passes lower; their value wins.
+    await supplement.search({ query: "x", maxResults: 1 });
+    expect(JSON.parse(calls[1]!.body!).limit).toBe(1);
+  });
+
+  it("test_supplement_returns_rows_with_plane_score_namespace_and_content", async () => {
+    const { fetch } = createMockFetch([{ status: 200, body: SAMPLE_RETRIEVE_RESPONSE }]);
+    const supplement = createCorpusSupplement({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    const results = await supplement.search({ query: "x" });
+
+    expect(results).toHaveLength(2);
+    const cur = results[0] as CorpusSearchResult;
+    expect(cur.corpus).toBe("musubi");
+    expect(cur.score).toBe(0.95);
+    expect(cur.kind).toBe("curated");
+    expect(cur.source).toBe("eric/_shared/curated");
+    expect(cur.id).toBe("ksuid-cur-1");
+    expect(cur.path).toBe("curated/ksuid-cur-1");
+    expect(cur.snippet).toContain("TypeScript");
+    expect(cur.provenanceLabel).toContain("Curated");
+
+    const concept = results[1] as CorpusSearchResult;
+    expect(concept.kind).toBe("concept");
+    expect(concept.provenanceLabel).toContain("hypothesis");
+  });
+
+  it("test_supplement_returns_empty_when_core_unreachable", async () => {
+    const { fetch } = createMockFetch([{ throw: new TypeError("fetch failed") }]);
+    const supplement = createCorpusSupplement({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    const results = await supplement.search({ query: "x" });
+
+    expect(results).toEqual([]);
+  });
+
+  it("test_supplement_returns_empty_when_disabled_in_config", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: SAMPLE_RETRIEVE_RESPONSE }]);
+    const supplement = createCorpusSupplement({
+      client: makeClient(fetch),
+      config: makeConfig({ supplement: { enabled: false } }),
+    });
+
+    const results = await supplement.search({ query: "x" });
+
+    expect(results).toEqual([]);
+    expect(calls).toEqual([]); // never even hit the network
+    expect(supplement.enabled).toBe(false);
+  });
+
+  it("test_supplement_uses_agent_presence_when_agent_id_is_provided", async () => {
+    const { fetch, calls } = createMockFetch([
+      { status: 200, body: { results: [], mode: "fast", limit: 5 } },
+    ]);
+    const supplement = createCorpusSupplement({
+      client: makeClient(fetch),
+      config: makeConfig({
+        presence: {
+          defaultId: "eric/openclaw",
+          perAgent: { aoi: "eric/aoi" },
+        },
+      }),
+    });
+
+    await supplement.search({ query: "x", agentSessionKey: "aoi" });
+
+    const body = JSON.parse(calls[0]!.body!);
+    expect(body.namespace).toBe("eric/aoi");
+  });
+
+  it("test_supplement_uses_default_presence_when_no_agent_id", async () => {
+    const { fetch, calls } = createMockFetch([
+      { status: 200, body: { results: [], mode: "fast", limit: 5 } },
+    ]);
+    const supplement = createCorpusSupplement({
+      client: makeClient(fetch),
+      config: makeConfig({
+        presence: {
+          defaultId: "eric/openclaw",
+          perAgent: { aoi: "eric/aoi" },
+        },
+      }),
+    });
+
+    await supplement.search({ query: "x" });
+
+    const body = JSON.parse(calls[0]!.body!);
+    expect(body.namespace).toBe("eric/openclaw");
+  });
+
+  it("get fetches a curated object by lookup path", async () => {
+    const { fetch, calls } = createMockFetch([
+      { status: 200, body: { object_id: "abc", content: "line one\nline two", title: "Note" } },
+    ]);
+    const supplement = createCorpusSupplement({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    const result = await supplement.get({ lookup: "curated/abc" });
+
+    expect(calls[0]?.url).toBe("https://musubi.test/v1/curated/abc");
+    expect(result?.title).toBe("Note");
+    expect(result?.content).toBe("line one\nline two");
+    expect(result?.lineCount).toBe(2);
+    expect(result?.kind).toBe("curated");
+  });
+
+  it("get returns null on fetch failure", async () => {
+    const { fetch } = createMockFetch([{ status: 404 }]);
+    const supplement = createCorpusSupplement({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    const result = await supplement.get({ lookup: "curated/missing" });
+
+    expect(result).toBeNull();
+  });
+
+  it("get returns null for malformed lookup", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: {} }]);
+    const supplement = createCorpusSupplement({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    expect(await supplement.get({ lookup: "no-slash" })).toBeNull();
+    expect(await supplement.get({ lookup: "/leading-slash" })).toBeNull();
+    expect(await supplement.get({ lookup: "trailing/" })).toBeNull();
+    expect(await supplement.get({ lookup: "unknown-plane/abc" })).toBeNull();
+    expect(calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Additive corpus supplement that contributes Musubi curated + concept results into OpenClaw's blended memory search. First arm of the sidecar-with-authority model from [ADR-0001](../docs/decisions/0001-sidecar-with-authority.md).

## Slice

Closes #4. Built on #2 (musubi-client) and #3 (presence-resolution).

## Changes

- `src/supplement/corpus.ts` — `createCorpusSupplement({ client, config })` returns search + get matching OpenClaw's `MemoryCorpusSupplement` shape.
- `tests/supplement/corpus.test.ts` — 8 contract tests + 3 bonus.
- `CHANGELOG.md` `[Unreleased]` updated.

## Behavior

- `search()` → `POST /v1/retrieve` with `mode: "fast"`, configured planes (default `[curated, concept]`), per-presence namespace via `agentSessionKey`, result cap honored both caller- and client-side.
- `get()` → `GET /v1/{curated,concepts,episodic,artifacts}/{id}` driven by lookup path `<plane>/<id>` returned in search results.
- Failures swallowed — Musubi unreachable yields empty results rather than failing OpenClaw's memory search.
- Provenance labels per plane so the model treats sources appropriately:
  - Curated → "Curated knowledge (high provenance)"
  - Concept → "Synthesized concept (system hypothesis)"
  - Episodic → "Recent episodic memory"
  - Artifact → "Source artifact"

The shape was verified against the locked OpenClaw SDK at `src/plugins/memory-state.ts` in `openclaw@2026.4.19-beta.2`. We mirror the structural type rather than depending on an SDK type re-export, so a future SDK reorganization doesn't force a coordinated release. The wiring slice (a future work item that registers this with `definePluginEntry`) will assert structural compatibility.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] `pnpm test` — 39/39
- [x] `pnpm build` clean
- [x] All 8 named contract tests present and green

## Docs

- [x] `CHANGELOG.md` updated.
- [ ] No contract change beyond what ADR-0001 already specified.

## Upstream coordination

None.