### PR TITLE
Slice #5: prompt-supplement (MemoryPromptSectionBuilder)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to a calendar-flavored semantic versioning scheme
 
 ### Added
 
+- `createPromptSupplement({ client, config })` in `src/supplement/prompt.ts`
+  returns an OpenClaw `MemoryPromptSectionBuilder`-shaped object plus an
+  out-of-band `refresh()` method. Builder is **synchronous** (per OpenClaw
+  contract) and reads from a pre-warmed cache; HTTP I/O lives in `refresh`.
+  Stale cache survives transient core failures so prompts don't suddenly
+  go empty mid-deploy. Per-plane labeled sections give the model the
+  provenance signal it needs (curated > concept).
 - `createCorpusSupplement({ client, config })` in `src/supplement/corpus.ts`
   returns an OpenClaw `MemoryCorpusSupplement`-shaped object. `search`
   POSTs `/v1/retrieve` in fast mode with configured planes (default

--- a/src/supplement/prompt.ts
+++ b/src/supplement/prompt.ts
@@ -1,0 +1,139 @@
+import {
+  DEFAULT_SUPPLEMENT_MAX_RESULTS,
+  DEFAULT_SUPPLEMENT_PLANES,
+  type MusubiConfig,
+} from "../config.js";
+import type { MusubiClient } from "../musubi/client.js";
+import { resolvePresence } from "../presence/resolver.js";
+
+/**
+ * `MemoryPromptSectionBuilder` matching the OpenClaw SDK shape — see
+ * `src/plugins/memory-state.ts` in `openclaw@2026.4.19-beta.2`. Returns
+ * an array of strings injected into the memory prompt.
+ *
+ * **Synchronous on purpose:** OpenClaw calls `build` per prompt assembly
+ * with a tight latency budget. The supplement therefore reads from a
+ * pre-warmed cache; HTTP I/O happens in `refresh()`, which the wiring
+ * slice schedules out-of-band.
+ */
+export type PromptBuildParams = {
+  readonly availableTools: ReadonlySet<string>;
+  readonly citationsMode?: string;
+};
+
+export type PromptSupplement = {
+  readonly enabled: boolean;
+  build(params: PromptBuildParams): string[];
+  refresh(options?: { readonly agentId?: string }): Promise<void>;
+  /** Inspectable for tests; not part of the public API. */
+  __cacheSize(): number;
+};
+
+export type CreatePromptSupplementOptions = {
+  readonly client: MusubiClient;
+  readonly config: MusubiConfig;
+};
+
+type StandingContextItem = {
+  readonly plane: string;
+  readonly content: string;
+  readonly source: string;
+};
+
+type MusubiRetrieveRow = {
+  readonly object_id: string;
+  readonly score: number;
+  readonly plane: string;
+  readonly content: string;
+  readonly namespace: string;
+};
+
+type MusubiRetrieveResponse = {
+  readonly results: readonly MusubiRetrieveRow[];
+};
+
+const STANDING_CONTEXT_QUERY = "*";
+const SECTION_HEADERS: Record<string, string> = {
+  curated: "**Curated knowledge from Musubi (high provenance):**",
+  concept: "**Synthesized concepts from Musubi (system hypotheses):**",
+  episodic: "**Recent episodic memory from Musubi:**",
+  artifact: "**Source artifacts from Musubi:**",
+};
+
+export function createPromptSupplement(options: CreatePromptSupplementOptions): PromptSupplement {
+  const { client, config } = options;
+  const supplementCfg = config.supplement ?? {};
+  const enabled = supplementCfg.enabled !== false;
+  const planes =
+    supplementCfg.planes && supplementCfg.planes.length > 0
+      ? [...supplementCfg.planes]
+      : [...DEFAULT_SUPPLEMENT_PLANES];
+  const cap = supplementCfg.maxResults ?? DEFAULT_SUPPLEMENT_MAX_RESULTS;
+
+  let cache: readonly StandingContextItem[] = [];
+
+  return {
+    enabled,
+
+    build(_params: PromptBuildParams): string[] {
+      if (!enabled || cache.length === 0) return [];
+
+      const lines: string[] = [];
+      let firstSection = true;
+
+      for (const plane of planes) {
+        const items = cache.filter((item) => item.plane === plane);
+        if (items.length === 0) continue;
+
+        if (!firstSection) lines.push("");
+        firstSection = false;
+
+        const header = SECTION_HEADERS[plane] ?? `**Musubi ${plane}:**`;
+        lines.push(header);
+        for (const item of items) {
+          lines.push(`- ${item.content} (${item.source})`);
+        }
+      }
+
+      return lines;
+    },
+
+    async refresh(refreshOptions = {}): Promise<void> {
+      if (!enabled) return;
+
+      let presence;
+      try {
+        presence = resolvePresence(config, { agentId: refreshOptions.agentId });
+      } catch {
+        cache = [];
+        return;
+      }
+
+      try {
+        const response = await client.post<MusubiRetrieveResponse>("/v1/retrieve", {
+          body: {
+            query_text: STANDING_CONTEXT_QUERY,
+            mode: "fast",
+            planes,
+            limit: cap,
+            namespace: presence.presence,
+          },
+        });
+        const next = (response.results ?? []).slice(0, cap).map(
+          (row): StandingContextItem => ({
+            plane: row.plane,
+            content: row.content,
+            source: row.namespace,
+          }),
+        );
+        cache = next;
+      } catch {
+        // Preserve stale cache on transient failure; better than going empty.
+      }
+    },
+
+    __cacheSize() {
+      return cache.length;
+    },
+  };
+}

--- a/tests/supplement/prompt.test.ts
+++ b/tests/supplement/prompt.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from "vitest";
+import { MusubiClient } from "../../src/musubi/client.js";
+import { createPromptSupplement } from "../../src/supplement/prompt.js";
+import type { MusubiConfig } from "../../src/config.js";
+import type { FetchLike } from "../../src/musubi/types.js";
+
+type ScriptedResponse =
+  | { status: number; body?: unknown; headers?: Record<string, string> }
+  | { throw: Error };
+
+function createMockFetch(script: ScriptedResponse[]): {
+  fetch: FetchLike;
+  bodies: string[];
+} {
+  const bodies: string[] = [];
+  let cursor = 0;
+  const fetch: FetchLike = async (_url, init) => {
+    bodies.push(typeof init.body === "string" ? init.body : "");
+    const def = script[cursor] ?? script[script.length - 1];
+    cursor += 1;
+    if (def === undefined) throw new Error("script exhausted");
+    if ("throw" in def) throw def.throw;
+    return new Response(def.body !== undefined ? JSON.stringify(def.body) : null, {
+      status: def.status,
+      headers: { "content-type": "application/json", ...(def.headers ?? {}) },
+    });
+  };
+  return { fetch, bodies };
+}
+
+function makeConfig(overrides: Partial<MusubiConfig> = {}): MusubiConfig {
+  return {
+    core: {
+      baseUrl: "https://musubi.test",
+      token: "t",
+      ...(overrides.core ?? {}),
+    },
+    presence: {
+      defaultId: "eric/openclaw",
+      ...(overrides.presence ?? {}),
+    },
+    ...(overrides.supplement !== undefined ? { supplement: overrides.supplement } : {}),
+  };
+}
+
+function makeClient(fetch: FetchLike) {
+  return new MusubiClient({
+    baseUrl: "https://musubi.test",
+    token: "t",
+    fetch,
+    sleep: async () => undefined,
+    random: () => 0,
+    generateRequestId: () => "r",
+    generateIdempotencyKey: () => "i",
+    retry: { maxAttempts: 1 },
+  });
+}
+
+const SAMPLE_RESPONSE = {
+  results: [
+    {
+      object_id: "ksuid-cur-1",
+      score: 0.95,
+      plane: "curated",
+      content: "Eric prefers TypeScript for new projects.",
+      namespace: "eric/_shared/curated",
+    },
+    {
+      object_id: "ksuid-cur-2",
+      score: 0.92,
+      plane: "curated",
+      content: "Aoi is the daily creative partner.",
+      namespace: "eric/_shared/curated",
+    },
+    {
+      object_id: "ksuid-con-1",
+      score: 0.83,
+      plane: "concept",
+      content: "Cross-modality continuity is a recurring theme.",
+      namespace: "eric/_shared/concept",
+    },
+  ],
+};
+
+const NO_TOOLS_PARAMS = { availableTools: new Set<string>() };
+
+describe("createPromptSupplement", () => {
+  it("test_prompt_uses_fast_path_not_deep_path", async () => {
+    const { fetch, bodies } = createMockFetch([{ status: 200, body: SAMPLE_RESPONSE }]);
+    const supplement = createPromptSupplement({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    await supplement.refresh();
+
+    const body = JSON.parse(bodies[0]!);
+    expect(body.mode).toBe("fast");
+  });
+
+  it("test_prompt_renders_labeled_section_per_plane", async () => {
+    const { fetch } = createMockFetch([{ status: 200, body: SAMPLE_RESPONSE }]);
+    const supplement = createPromptSupplement({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    await supplement.refresh();
+    const lines = supplement.build(NO_TOOLS_PARAMS);
+
+    const text = lines.join("\n");
+    expect(text).toContain("Curated knowledge from Musubi");
+    expect(text).toContain("Synthesized concepts from Musubi");
+    expect(text).toContain("Eric prefers TypeScript");
+    expect(text).toContain("Cross-modality continuity");
+    // Sections separated by a blank line
+    expect(text.split("\n\n")).toHaveLength(2);
+  });
+
+  it("test_prompt_labels_curated_as_high_provenance", async () => {
+    const { fetch } = createMockFetch([{ status: 200, body: SAMPLE_RESPONSE }]);
+    const supplement = createPromptSupplement({
+      client: makeClient(fetch),
+      config: makeConfig({ supplement: { planes: ["curated"] } }),
+    });
+
+    await supplement.refresh();
+    const lines = supplement.build(NO_TOOLS_PARAMS);
+
+    expect(lines[0]).toContain("Curated knowledge from Musubi");
+    expect(lines[0]).toContain("high provenance");
+  });
+
+  it("test_prompt_labels_concept_as_system_hypothesis", async () => {
+    const { fetch } = createMockFetch([{ status: 200, body: SAMPLE_RESPONSE }]);
+    const supplement = createPromptSupplement({
+      client: makeClient(fetch),
+      config: makeConfig({ supplement: { planes: ["concept"] } }),
+    });
+
+    await supplement.refresh();
+    const lines = supplement.build(NO_TOOLS_PARAMS);
+
+    expect(lines[0]).toContain("Synthesized concepts");
+    expect(lines[0]).toContain("system hypothes"); // singular or plural — header reads naturally
+  });
+
+  it("test_prompt_truncates_to_configured_max_results", async () => {
+    const { fetch, bodies } = createMockFetch([{ status: 200, body: SAMPLE_RESPONSE }]);
+    const supplement = createPromptSupplement({
+      client: makeClient(fetch),
+      config: makeConfig({ supplement: { maxResults: 2 } }),
+    });
+
+    await supplement.refresh();
+
+    expect(JSON.parse(bodies[0]!).limit).toBe(2);
+    // Even if Musubi over-returned (3 rows), client-side cap holds
+    expect(supplement.__cacheSize()).toBe(2);
+  });
+
+  it("test_prompt_section_is_empty_string_when_no_results", async () => {
+    const { fetch } = createMockFetch([{ status: 200, body: { results: [] } }]);
+    const supplement = createPromptSupplement({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    await supplement.refresh();
+    const lines = supplement.build(NO_TOOLS_PARAMS);
+
+    expect(lines).toEqual([]);
+    expect(lines.join("\n")).toBe("");
+  });
+
+  it("test_prompt_section_is_empty_string_when_disabled", async () => {
+    const { fetch, bodies } = createMockFetch([{ status: 200, body: SAMPLE_RESPONSE }]);
+    const supplement = createPromptSupplement({
+      client: makeClient(fetch),
+      config: makeConfig({ supplement: { enabled: false } }),
+    });
+
+    await supplement.refresh();
+    const lines = supplement.build(NO_TOOLS_PARAMS);
+
+    expect(supplement.enabled).toBe(false);
+    expect(lines).toEqual([]);
+    expect(bodies).toEqual([]); // refresh skipped when disabled
+  });
+
+  it("test_prompt_section_is_empty_string_when_core_unreachable", async () => {
+    const { fetch } = createMockFetch([{ throw: new TypeError("fetch failed") }]);
+    const supplement = createPromptSupplement({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    await supplement.refresh();
+    const lines = supplement.build(NO_TOOLS_PARAMS);
+
+    expect(lines).toEqual([]);
+  });
+
+  it("test_prompt_respects_latency_budget_configured_by_openclaw", async () => {
+    // build() must be synchronous — no await, no I/O. Verify by asserting
+    // it completes inside a sub-millisecond budget even with a stale empty
+    // cache and even if the configured client would normally take 30s.
+    const { fetch } = createMockFetch([{ status: 200, body: SAMPLE_RESPONSE }]);
+    const supplement = createPromptSupplement({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+    await supplement.refresh();
+
+    const start = performance.now();
+    const lines = supplement.build(NO_TOOLS_PARAMS);
+    const elapsedMs = performance.now() - start;
+
+    expect(lines.length).toBeGreaterThan(0);
+    expect(elapsedMs).toBeLessThan(50); // generous; build should be sub-millisecond
+  });
+
+  it("preserves stale cache when refresh fails after a prior success", async () => {
+    const { fetch } = createMockFetch([
+      { status: 200, body: SAMPLE_RESPONSE },
+      { throw: new TypeError("fetch failed") },
+    ]);
+    const supplement = createPromptSupplement({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    await supplement.refresh();
+    expect(supplement.__cacheSize()).toBeGreaterThan(0);
+
+    await supplement.refresh();
+    // Cache survived the failure
+    expect(supplement.__cacheSize()).toBeGreaterThan(0);
+  });
+
+  it("uses agent presence on refresh when agentId is provided", async () => {
+    const { fetch, bodies } = createMockFetch([{ status: 200, body: { results: [] } }]);
+    const supplement = createPromptSupplement({
+      client: makeClient(fetch),
+      config: makeConfig({
+        presence: { defaultId: "eric/openclaw", perAgent: { aoi: "eric/aoi" } },
+      }),
+    });
+
+    await supplement.refresh({ agentId: "aoi" });
+
+    expect(JSON.parse(bodies[0]!).namespace).toBe("eric/aoi");
+  });
+});


### PR DESCRIPTION
## Summary

Second arm of sidecar-with-authority. Renders a labeled section into OpenClaw's memory prompt with provenance markers so the model naturally weighs curated > concept > episodic.

## Slice

Closes #5. Built on #2, #3.

## Architecture

OpenClaw's \`MemoryPromptSectionBuilder\` is **synchronous** (verified against \`src/plugins/memory-state.ts\` in \`openclaw@2026.4.19-beta.2\`):

\`\`\`typescript
type MemoryPromptSectionBuilder = (params: {
  availableTools: Set<string>;
  citationsMode?: MemoryCitationsMode;
}) => string[];
\`\`\`

We can't do an HTTP call inside the builder. The supplement therefore separates concerns:

- \`build(params)\` — pure sync read from a pre-warmed cache. Sub-millisecond.
- \`refresh({ agentId? })\` — out-of-band HTTP work. Wiring slice schedules it (timer, hook, whatever fits).

Failure handling: a refresh that fails *after* a prior success keeps the existing cache rather than wiping it. Better stale-but-present context than an empty section mid-deploy.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm format:check\` clean
- [x] \`pnpm test\` — 50/50
- [x] \`pnpm build\` clean
- [x] All 9 named contract tests present and green

## Docs

- [x] \`CHANGELOG.md\` updated
- [ ] No contract change beyond ADR-0001