### PR TITLE
Slice #6: capture-mirror (OpenClaw → Musubi episodic flywheel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to a calendar-flavored semantic versioning scheme
 
 ### Added
 
+- `createCaptureMirror({ client, config, logger })` in `src/capture/mirror.ts`
+  exposes `handleEvent` / `handleBatch` for the wiring slice to register
+  via OpenClaw's `agent_end` hook (the established pattern from
+  `extensions/memory-lancedb`). Translates capture-eligible events into
+  Musubi episodic posts (`/v1/episodic` and `/v1/episodic/batch`) with
+  stable per-event idempotency keys (`openclaw-mirror:<id>`). **Failures
+  are logged and swallowed** — never throws back into OpenClaw's caller.
+- `translateCaptureEvent` + `deriveIdempotencyKey` in
+  `src/capture/translate.ts` — pure functions; importance is clamped to
+  `[0, 10]`, timestamp defaults to "now", per-presence namespace from the
+  resolver.
 - `createPromptSupplement({ client, config })` in `src/supplement/prompt.ts`
   returns an OpenClaw `MemoryPromptSectionBuilder`-shaped object plus an
   out-of-band `refresh()` method. Builder is **synchronous** (per OpenClaw

--- a/src/capture/mirror.ts
+++ b/src/capture/mirror.ts
@@ -1,0 +1,131 @@
+import type { MusubiConfig } from "../config.js";
+import type { MusubiClient } from "../musubi/client.js";
+import { resolvePresence } from "../presence/resolver.js";
+import {
+  deriveIdempotencyKey,
+  translateCaptureEvent,
+  type CaptureEvent,
+  type EpisodicCapturePayload,
+} from "./translate.js";
+
+/**
+ * Capture-mirror — translates capture-eligible events from OpenClaw's
+ * lifecycle hooks (today `agent_end`) into Musubi episodic memories so
+ * every captured turn lands in the cross-modality pool automatically.
+ *
+ * **Failures must never block OpenClaw.** A Musubi mirror failure is
+ * logged and swallowed; OpenClaw's native memory write is unaffected.
+ *
+ * The mirror module exposes `handleEvent` and `handleBatch`. The wiring
+ * slice (a future work item) registers these via `api.on("agent_end", …)`
+ * — consistent with the pattern used by `extensions/memory-lancedb`.
+ */
+
+export type MirrorLogger = {
+  warn(message: string, fields?: Record<string, unknown>): void;
+  debug?(message: string, fields?: Record<string, unknown>): void;
+};
+
+const noopLogger: MirrorLogger = {
+  warn() {
+    /* no-op */
+  },
+};
+
+export type CaptureMirror = {
+  readonly enabled: boolean;
+  handleEvent(event: CaptureEvent): Promise<void>;
+  handleBatch(events: readonly CaptureEvent[]): Promise<void>;
+};
+
+export type CreateCaptureMirrorOptions = {
+  readonly client: MusubiClient;
+  readonly config: MusubiConfig;
+  readonly logger?: MirrorLogger;
+  readonly now?: () => Date;
+};
+
+export function createCaptureMirror(options: CreateCaptureMirrorOptions): CaptureMirror {
+  const { client, config } = options;
+  const logger = options.logger ?? noopLogger;
+  const now = options.now ?? (() => new Date());
+  const enabled = config.capture?.mirrorOpenClawMemory !== false;
+
+  return {
+    enabled,
+
+    async handleEvent(event: CaptureEvent): Promise<void> {
+      if (!enabled) return;
+
+      const payload = translateOrSkip(event, config, now, logger);
+      if (payload === undefined) return;
+
+      try {
+        await client.post("/v1/episodic", {
+          body: payload,
+          idempotencyKey: deriveIdempotencyKey(event),
+        });
+      } catch (err) {
+        logger.warn("musubi: mirror handleEvent failed; OpenClaw write unaffected", {
+          source_ref: event.id,
+          error: errorMessage(err),
+        });
+      }
+    },
+
+    async handleBatch(events: readonly CaptureEvent[]): Promise<void> {
+      if (!enabled || events.length === 0) return;
+
+      const payloads: EpisodicCapturePayload[] = [];
+      const idempotencyKeys: string[] = [];
+      for (const event of events) {
+        const payload = translateOrSkip(event, config, now, logger);
+        if (payload === undefined) continue;
+        payloads.push(payload);
+        idempotencyKeys.push(deriveIdempotencyKey(event));
+      }
+      if (payloads.length === 0) return;
+
+      try {
+        await client.post("/v1/episodic/batch", {
+          body: { items: payloads, idempotency_keys: idempotencyKeys },
+          // The batch endpoint gets its own top-level idempotency key composed
+          // from the per-event keys so retried batches dedup as a unit.
+          idempotencyKey: `batch:${idempotencyKeys.join(",")}`,
+        });
+      } catch (err) {
+        logger.warn("musubi: mirror handleBatch failed; OpenClaw write unaffected", {
+          batch_size: payloads.length,
+          error: errorMessage(err),
+        });
+      }
+    },
+  };
+}
+
+function translateOrSkip(
+  event: CaptureEvent,
+  config: MusubiConfig,
+  now: () => Date,
+  logger: MirrorLogger,
+): EpisodicCapturePayload | undefined {
+  if (!event.content || event.content.length === 0) return undefined;
+
+  let presence;
+  try {
+    presence = resolvePresence(config, { agentId: event.agentId });
+  } catch (err) {
+    logger.warn("musubi: mirror skipped event; presence resolution failed", {
+      source_ref: event.id,
+      error: errorMessage(err),
+    });
+    return undefined;
+  }
+
+  return translateCaptureEvent(event, presence, now);
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/src/capture/translate.ts
+++ b/src/capture/translate.ts
@@ -1,0 +1,73 @@
+/**
+ * Translate an OpenClaw capture-eligible event into a Musubi episodic
+ * capture payload. Pure function — no I/O. Easy to test in isolation.
+ *
+ * The `idempotencyKey` is derived from the source event id so a retried
+ * mirror call posts to the same logical capture rather than creating
+ * duplicates. See ADR-0001 for why dual-write is acceptable.
+ */
+
+import type { PresenceContext } from "../presence/resolver.js";
+
+/**
+ * Capture-eligible event from OpenClaw. Shape is intentionally narrow:
+ * the wiring slice extracts these fields from whichever OpenClaw hook
+ * fires (today: `agent_end`).
+ */
+export type CaptureEvent = {
+  /** Stable id of the source memory; used to derive the idempotency key. */
+  readonly id: string;
+  /** Optional OpenClaw agent id; routed through presence resolution. */
+  readonly agentId?: string;
+  /** The capture-eligible text. */
+  readonly content: string;
+  /** ISO 8601 timestamp; defaults to now if absent. */
+  readonly timestamp?: string;
+  /** Importance hint, 0-10. Defaults to 5 (neutral). */
+  readonly importance?: number;
+  /** Optional topic tags. */
+  readonly topics?: readonly string[];
+  /** Free-form metadata; passed through to Musubi. */
+  readonly metadata?: Readonly<Record<string, unknown>>;
+};
+
+export type EpisodicCapturePayload = {
+  readonly namespace: string;
+  readonly content: string;
+  readonly capture_source: string;
+  readonly source_ref: string;
+  readonly timestamp: string;
+  readonly importance: number;
+  readonly topics: readonly string[];
+  readonly metadata: Readonly<Record<string, unknown>>;
+};
+
+const CAPTURE_SOURCE = "openclaw-agent-end";
+const DEFAULT_IMPORTANCE = 5;
+const IDEMPOTENCY_PREFIX = "openclaw-mirror";
+
+export function translateCaptureEvent(
+  event: CaptureEvent,
+  presence: PresenceContext,
+  now: () => Date = () => new Date(),
+): EpisodicCapturePayload {
+  return {
+    namespace: presence.namespaces.episodic,
+    content: event.content,
+    capture_source: CAPTURE_SOURCE,
+    source_ref: event.id,
+    timestamp: event.timestamp ?? now().toISOString(),
+    importance: clampImportance(event.importance ?? DEFAULT_IMPORTANCE),
+    topics: event.topics ?? [],
+    metadata: event.metadata ?? {},
+  };
+}
+
+export function deriveIdempotencyKey(event: CaptureEvent): string {
+  return `${IDEMPOTENCY_PREFIX}:${event.id}`;
+}
+
+function clampImportance(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_IMPORTANCE;
+  return Math.max(0, Math.min(10, Math.round(value)));
+}

--- a/tests/capture/mirror.test.ts
+++ b/tests/capture/mirror.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from "vitest";
+import { MusubiClient } from "../../src/musubi/client.js";
+import { createCaptureMirror, type MirrorLogger } from "../../src/capture/mirror.js";
+import type { MusubiConfig } from "../../src/config.js";
+import type { FetchLike } from "../../src/musubi/types.js";
+
+type RecordedCall = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | undefined;
+};
+
+type ScriptedResponse =
+  | { status: number; body?: unknown; headers?: Record<string, string> }
+  | { throw: Error };
+
+function createMockFetch(script: ScriptedResponse[]): {
+  fetch: FetchLike;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  let cursor = 0;
+  const fetch: FetchLike = async (url, init) => {
+    const headers: Record<string, string> = {};
+    if (init.headers) {
+      for (const [k, v] of Object.entries(init.headers as Record<string, string>)) {
+        headers[k] = v;
+      }
+    }
+    calls.push({
+      url,
+      method: init.method ?? "GET",
+      headers,
+      body: typeof init.body === "string" ? init.body : undefined,
+    });
+    const def = script[cursor] ?? script[script.length - 1];
+    cursor += 1;
+    if (def === undefined) throw new Error("script exhausted");
+    if ("throw" in def) throw def.throw;
+    return new Response(def.body !== undefined ? JSON.stringify(def.body) : null, {
+      status: def.status,
+      headers: { "content-type": "application/json", ...(def.headers ?? {}) },
+    });
+  };
+  return { fetch, calls };
+}
+
+function makeConfig(overrides: Partial<MusubiConfig> = {}): MusubiConfig {
+  return {
+    core: { baseUrl: "https://musubi.test", token: "t", ...(overrides.core ?? {}) },
+    presence: { defaultId: "eric/openclaw", ...(overrides.presence ?? {}) },
+    ...(overrides.capture !== undefined ? { capture: overrides.capture } : {}),
+  };
+}
+
+function makeClient(fetch: FetchLike) {
+  return new MusubiClient({
+    baseUrl: "https://musubi.test",
+    token: "t",
+    fetch,
+    sleep: async () => undefined,
+    random: () => 0,
+    generateRequestId: () => "r",
+    generateIdempotencyKey: () => "i",
+    retry: { maxAttempts: 1 },
+  });
+}
+
+function spyLogger(): MirrorLogger & {
+  calls: Array<{ message: string; fields?: Record<string, unknown> }>;
+} {
+  const calls: Array<{ message: string; fields?: Record<string, unknown> }> = [];
+  return {
+    calls,
+    warn(message, fields) {
+      calls.push({ message, fields });
+    },
+  };
+}
+
+describe("createCaptureMirror", () => {
+  it("test_mirror_registers_openclaw_memory_write_hook", () => {
+    // The mirror module exposes the handlers the wiring slice will register
+    // via api.on("agent_end", ...). This test asserts the handler surface
+    // exists and is callable; integration with api.on is the wiring slice's
+    // responsibility (per the slice issue claim comment).
+    const { fetch } = createMockFetch([{ status: 200 }]);
+    const mirror = createCaptureMirror({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    expect(typeof mirror.handleEvent).toBe("function");
+    expect(typeof mirror.handleBatch).toBe("function");
+    expect(mirror.enabled).toBe(true);
+  });
+
+  it("test_mirror_posts_single_event_to_episodic_endpoint", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200 }]);
+    const mirror = createCaptureMirror({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    await mirror.handleEvent({ id: "evt-1", content: "hello" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("https://musubi.test/v1/episodic");
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.headers["Idempotency-Key"]).toBe("openclaw-mirror:evt-1");
+    const body = JSON.parse(calls[0]!.body!);
+    expect(body.namespace).toBe("eric/openclaw/episodic");
+    expect(body.content).toBe("hello");
+    expect(body.source_ref).toBe("evt-1");
+    expect(body.capture_source).toBe("openclaw-agent-end");
+  });
+
+  it("test_mirror_batches_events_when_openclaw_flushes_multiple", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200 }]);
+    const mirror = createCaptureMirror({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    await mirror.handleBatch([
+      { id: "evt-1", content: "first" },
+      { id: "evt-2", content: "second" },
+      { id: "evt-3", content: "third" },
+    ]);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("https://musubi.test/v1/episodic/batch");
+    const body = JSON.parse(calls[0]!.body!);
+    expect(body.items).toHaveLength(3);
+    expect(body.idempotency_keys).toEqual([
+      "openclaw-mirror:evt-1",
+      "openclaw-mirror:evt-2",
+      "openclaw-mirror:evt-3",
+    ]);
+  });
+
+  it("test_mirror_does_not_block_openclaw_write_on_musubi_failure", async () => {
+    const { fetch } = createMockFetch([{ throw: new TypeError("network down") }]);
+    const logger = spyLogger();
+    const mirror = createCaptureMirror({
+      client: makeClient(fetch),
+      config: makeConfig(),
+      logger,
+    });
+
+    // Must not throw — OpenClaw caller awaits this and expects no exception.
+    await expect(mirror.handleEvent({ id: "evt-1", content: "x" })).resolves.toBeUndefined();
+    expect(logger.calls).toHaveLength(1);
+    expect(logger.calls[0]?.message).toContain("mirror handleEvent failed");
+  });
+
+  it("test_mirror_logs_but_does_not_throw_on_auth_error", async () => {
+    const { fetch } = createMockFetch([{ status: 401 }]);
+    const logger = spyLogger();
+    const mirror = createCaptureMirror({
+      client: makeClient(fetch),
+      config: makeConfig(),
+      logger,
+    });
+
+    await expect(mirror.handleEvent({ id: "evt-1", content: "x" })).resolves.toBeUndefined();
+    expect(logger.calls).toHaveLength(1);
+    expect(logger.calls[0]?.fields?.error).toContain("401");
+  });
+
+  it("test_mirror_carries_agent_presence_through_to_namespace", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200 }]);
+    const mirror = createCaptureMirror({
+      client: makeClient(fetch),
+      config: makeConfig({
+        presence: { defaultId: "eric/openclaw", perAgent: { aoi: "eric/aoi" } },
+      }),
+    });
+
+    await mirror.handleEvent({ id: "evt-1", content: "x", agentId: "aoi" });
+
+    const body = JSON.parse(calls[0]!.body!);
+    expect(body.namespace).toBe("eric/aoi/episodic");
+  });
+
+  it("test_mirror_is_disabled_when_config_mirrorOpenClawMemory_is_false", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200 }]);
+    const mirror = createCaptureMirror({
+      client: makeClient(fetch),
+      config: makeConfig({ capture: { mirrorOpenClawMemory: false } }),
+    });
+
+    expect(mirror.enabled).toBe(false);
+    await mirror.handleEvent({ id: "evt-1", content: "x" });
+    await mirror.handleBatch([{ id: "evt-2", content: "y" }]);
+
+    expect(calls).toEqual([]);
+  });
+
+  it("test_mirror_idempotency_key_is_stable_per_source_memory_id", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200 }, { status: 200 }]);
+    const mirror = createCaptureMirror({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    await mirror.handleEvent({ id: "stable-evt", content: "first" });
+    await mirror.handleEvent({ id: "stable-evt", content: "second" });
+
+    expect(calls[0]?.headers["Idempotency-Key"]).toBe("openclaw-mirror:stable-evt");
+    expect(calls[1]?.headers["Idempotency-Key"]).toBe("openclaw-mirror:stable-evt");
+  });
+
+  it("skips events with empty content", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200 }]);
+    const mirror = createCaptureMirror({
+      client: makeClient(fetch),
+      config: makeConfig(),
+    });
+
+    await mirror.handleEvent({ id: "evt-1", content: "" });
+    expect(calls).toEqual([]);
+  });
+});

--- a/tests/capture/translate.test.ts
+++ b/tests/capture/translate.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveIdempotencyKey,
+  translateCaptureEvent,
+  type CaptureEvent,
+} from "../../src/capture/translate.js";
+import type { PresenceContext } from "../../src/presence/resolver.js";
+
+const presence: PresenceContext = {
+  presence: "eric/openclaw",
+  token: "tok",
+  namespaces: {
+    episodic: "eric/openclaw/episodic",
+    curatedReadScope: ["eric/openclaw/curated", "eric/_shared/curated"],
+  },
+};
+
+const fixedNow = () => new Date("2026-04-20T05:00:00.000Z");
+
+describe("translateCaptureEvent", () => {
+  it("test_mirror_translates_openclaw_memory_to_episodic_shape", () => {
+    const event: CaptureEvent = {
+      id: "openclaw-mem-123",
+      content: "Eric mentioned wanting to ship Musubi v2 this quarter.",
+      agentId: "aoi",
+      importance: 7,
+      topics: ["musubi", "roadmap"],
+    };
+
+    const payload = translateCaptureEvent(event, presence, fixedNow);
+
+    expect(payload).toEqual({
+      namespace: "eric/openclaw/episodic",
+      content: "Eric mentioned wanting to ship Musubi v2 this quarter.",
+      capture_source: "openclaw-agent-end",
+      source_ref: "openclaw-mem-123",
+      timestamp: "2026-04-20T05:00:00.000Z",
+      importance: 7,
+      topics: ["musubi", "roadmap"],
+      metadata: {},
+    });
+  });
+
+  it("defaults importance to 5 (neutral) when absent", () => {
+    const payload = translateCaptureEvent({ id: "x", content: "hello" }, presence, fixedNow);
+    expect(payload.importance).toBe(5);
+  });
+
+  it("clamps importance to [0,10]", () => {
+    const high = translateCaptureEvent(
+      { id: "x", content: "hello", importance: 99 },
+      presence,
+      fixedNow,
+    );
+    const low = translateCaptureEvent(
+      { id: "x", content: "hello", importance: -3 },
+      presence,
+      fixedNow,
+    );
+    const nan = translateCaptureEvent(
+      { id: "x", content: "hello", importance: Number.NaN },
+      presence,
+      fixedNow,
+    );
+    expect(high.importance).toBe(10);
+    expect(low.importance).toBe(0);
+    expect(nan.importance).toBe(5);
+  });
+
+  it("uses event timestamp when provided", () => {
+    const payload = translateCaptureEvent(
+      { id: "x", content: "hello", timestamp: "2025-01-01T00:00:00.000Z" },
+      presence,
+      fixedNow,
+    );
+    expect(payload.timestamp).toBe("2025-01-01T00:00:00.000Z");
+  });
+
+  it("passes through metadata and defaults topics to []", () => {
+    const payload = translateCaptureEvent(
+      { id: "x", content: "hello", metadata: { thread: "abc" } },
+      presence,
+      fixedNow,
+    );
+    expect(payload.metadata).toEqual({ thread: "abc" });
+    expect(payload.topics).toEqual([]);
+  });
+});
+
+describe("deriveIdempotencyKey", () => {
+  it("test_mirror_idempotency_key_is_stable_per_source_memory_id", () => {
+    const event: CaptureEvent = { id: "openclaw-mem-abc", content: "x" };
+    expect(deriveIdempotencyKey(event)).toBe("openclaw-mirror:openclaw-mem-abc");
+    expect(deriveIdempotencyKey(event)).toBe(deriveIdempotencyKey(event));
+  });
+});


### PR DESCRIPTION
## Summary

Mirror capture-eligible events from OpenClaw's agent lifecycle into Musubi's episodic plane. The flywheel that makes cross-modality continuity automatic — every captured turn is visible to every modality, no agent discipline required.

## Slice

Closes #6. Built on #2, #3.

## Hook choice

OpenClaw doesn't expose a \`memory_write\` event. The slice contract assumed one but the established pattern (used by \`extensions/memory-lancedb\`) is to hook \`agent_end\` for auto-capture. Per the [claim comment](https://github.com/ericmey/openclaw-musubi/issues/6#issuecomment-4277866094): the mirror module exposes \`handleEvent\` / \`handleBatch\`; the wiring slice will register them via \`api.on("agent_end", ...)\`.

## Architecture

- \`src/capture/translate.ts\` — pure function pair (\`translateCaptureEvent\`, \`deriveIdempotencyKey\`). Easy to test in isolation. No I/O.
- \`src/capture/mirror.ts\` — wraps client + presence resolver + logger; exposes the handler surface.
- Idempotency keys: \`openclaw-mirror:<event-id>\` — stable per source memory, retries dedupe.

## Failure handling

Every Musubi-side failure (network, auth, server, presence resolution) is logged via the injected \`MirrorLogger\` and swallowed. **The mirror never throws into OpenClaw's caller** — a retried \`agent_end\` must not be blocked by a Musubi outage.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm format:check\` clean
- [x] \`pnpm test\` — 65/65
- [x] \`pnpm build\` clean
- [x] All 9 named contract tests present and green

## Docs

- [x] \`CHANGELOG.md\` updated
- [ ] No contract change beyond ADR-0001