### PR TITLE
Slice #7: thought-stream (SSE consumer for /v1/thoughts/stream)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to a calendar-flavored semantic versioning scheme
 
 ### Added
 
+- `createThoughtStream({ config, ... })` in `src/thoughts/stream.ts` — SSE
+  consumer for `GET /v1/thoughts/stream` with all six consumer-expectation
+  rules: exponential backoff with jitter, persisted `Last-Event-ID`,
+  bounded dedup set, 403 no-reconnect, 60s ping-gap timeout, lex string
+  comparison for object ids. Zero-dep SSE frame parser. Injectable fetch,
+  dedup, persistence, random, sleep, now — fully deterministic tests.
+- `BoundedDedupSet` in `src/thoughts/dedup.ts` — max-size + TTL bounded
+  `Map`-backed dedup with insertion-order eviction.
+- `InMemoryLastEventIdStore` + `LastEventIdStore` interface in
+  `src/thoughts/persistence.ts` — production consumers inject a
+  runtime-backed implementation.
+- `nextSseBackoffMs` in `src/thoughts/backoff.ts` — pure helper matching
+  the spec formula: `min(2^n * 1000ms + rand(0, 1000ms), 60s)`.
 - `createCaptureMirror({ client, config, logger })` in `src/capture/mirror.ts`
   exposes `handleEvent` / `handleBatch` for the wiring slice to register
   via OpenClaw's `agent_end` hook (the established pattern from

--- a/src/thoughts/backoff.ts
+++ b/src/thoughts/backoff.ts
@@ -1,0 +1,34 @@
+/**
+ * Exponential backoff with jitter for the SSE thought-stream reconnect.
+ *
+ * Per `docs/api-contract.md` §SSE rule 1 (mirroring upstream
+ * canonical-api §5 "Consumer expectations"):
+ *
+ *     delay_ms = min(2^n * 1000ms + rand(0, 1000ms), 60s)
+ *
+ * `n` starts at 0, increments on each failed reconnect attempt, and is
+ * reset to 0 by the consumer once a connection has been stable for
+ * 5 minutes.
+ *
+ * Pure function. Tests pin `random` to a fixed value to assert the
+ * progression and the cap.
+ */
+
+export const SSE_BASE_DELAY_MS = 1_000;
+export const SSE_JITTER_MS = 1_000;
+export const SSE_MAX_DELAY_MS = 60_000;
+
+export function nextSseBackoffMs(
+  attempt: number,
+  options: { readonly maxDelayMs?: number; readonly random?: () => number } = {},
+): number {
+  if (attempt < 0) {
+    throw new RangeError(`attempt must be >= 0 (got ${attempt})`);
+  }
+  const maxDelayMs = options.maxDelayMs ?? SSE_MAX_DELAY_MS;
+  const random = options.random ?? Math.random;
+
+  const exponential = SSE_BASE_DELAY_MS * Math.pow(2, attempt);
+  const jitter = random() * SSE_JITTER_MS;
+  return Math.min(exponential + jitter, maxDelayMs);
+}

--- a/src/thoughts/dedup.ts
+++ b/src/thoughts/dedup.ts
@@ -1,0 +1,69 @@
+/**
+ * Bounded dedup set with TTL.
+ *
+ * Per `docs/api-contract.md` §SSE rule 3: keep the last 1000 `object_id`s
+ * or a 1-hour TTL, whichever bound is hit first. Replay on reconnect can
+ * overlap with in-flight delivery; the set ensures we never deliver the
+ * same thought twice in-process.
+ *
+ * Implementation: a `Map<id, insertedAt>` with insertion-order eviction.
+ * `Map` preserves insertion order so the oldest key is always the first
+ * iterated, giving O(1) eviction without a separate LRU list.
+ */
+
+export type BoundedDedupSetOptions = {
+  readonly maxSize?: number;
+  readonly ttlMs?: number;
+  readonly now?: () => number;
+};
+
+export const DEFAULT_DEDUP_MAX_SIZE = 1_000;
+export const DEFAULT_DEDUP_TTL_MS = 60 * 60 * 1_000; // 1 hour
+
+export class BoundedDedupSet {
+  readonly #maxSize: number;
+  readonly #ttlMs: number;
+  readonly #now: () => number;
+  readonly #seen: Map<string, number>;
+
+  constructor(options: BoundedDedupSetOptions = {}) {
+    this.#maxSize = options.maxSize ?? DEFAULT_DEDUP_MAX_SIZE;
+    this.#ttlMs = options.ttlMs ?? DEFAULT_DEDUP_TTL_MS;
+    this.#now = options.now ?? Date.now;
+    this.#seen = new Map();
+  }
+
+  has(id: string): boolean {
+    const insertedAt = this.#seen.get(id);
+    if (insertedAt === undefined) return false;
+    if (this.#isExpired(insertedAt)) {
+      this.#seen.delete(id);
+      return false;
+    }
+    return true;
+  }
+
+  /** Returns `true` if the id was newly added; `false` if already present. */
+  add(id: string): boolean {
+    if (this.has(id)) return false;
+    this.#seen.set(id, this.#now());
+    this.#evictIfOverCap();
+    return true;
+  }
+
+  size(): number {
+    return this.#seen.size;
+  }
+
+  #isExpired(insertedAt: number): boolean {
+    return this.#now() - insertedAt > this.#ttlMs;
+  }
+
+  #evictIfOverCap(): void {
+    while (this.#seen.size > this.#maxSize) {
+      const oldest = this.#seen.keys().next().value;
+      if (oldest === undefined) break;
+      this.#seen.delete(oldest);
+    }
+  }
+}

--- a/src/thoughts/persistence.ts
+++ b/src/thoughts/persistence.ts
@@ -1,0 +1,39 @@
+/**
+ * Last-Event-ID persistence abstraction.
+ *
+ * Per `docs/api-contract.md` §SSE rule 2: the consumer persists the most
+ * recent acknowledged `id` so a service-worker restart resumes from where
+ * it left off rather than replaying the entire thoughts plane.
+ *
+ * The interface is async-by-shape so a real implementation can hit
+ * IndexedDB / `chrome.storage.local` / a file / OpenClaw's plugin runtime
+ * store without forcing the consumer to know which. This module ships
+ * an `InMemoryLastEventIdStore` for tests; production consumers inject
+ * a runtime-backed store.
+ */
+
+export type LastEventIdStore = {
+  read(): Promise<string | undefined>;
+  write(id: string): Promise<void>;
+  clear(): Promise<void>;
+};
+
+export class InMemoryLastEventIdStore implements LastEventIdStore {
+  #value: string | undefined;
+
+  constructor(initial?: string) {
+    this.#value = initial;
+  }
+
+  async read(): Promise<string | undefined> {
+    return this.#value;
+  }
+
+  async write(id: string): Promise<void> {
+    this.#value = id;
+  }
+
+  async clear(): Promise<void> {
+    this.#value = undefined;
+  }
+}

--- a/src/thoughts/stream.ts
+++ b/src/thoughts/stream.ts
@@ -1,0 +1,332 @@
+import type { MusubiConfig } from "../config.js";
+import { resolvePresence } from "../presence/resolver.js";
+import { nextSseBackoffMs } from "./backoff.js";
+import { BoundedDedupSet } from "./dedup.js";
+import { InMemoryLastEventIdStore, type LastEventIdStore } from "./persistence.js";
+
+/**
+ * SSE consumer for Musubi's `GET /v1/thoughts/stream` endpoint.
+ *
+ * Implements all six consumer-expectation rules from
+ * `docs/api-contract.md` §SSE — backoff with jitter, persisted
+ * Last-Event-ID resume, bounded dedup, 403 no-reconnect, ping-gap
+ * timeout, lex (string) `object_id` comparison.
+ *
+ * Public surface: `createThoughtStream(opts).start(handlers)` and
+ * `.stop()`. `start` enters a reconnect loop; `stop` aborts the current
+ * connection and prevents further reconnects.
+ */
+
+export type ThoughtPayload = {
+  readonly object_id: string;
+  readonly from_presence: string;
+  readonly to_presence: string;
+  readonly namespace: string;
+  readonly content: string;
+  readonly channel?: string;
+  readonly importance?: number;
+  readonly sent_at: string;
+};
+
+export type ThoughtStreamHandlers = {
+  onThought: (thought: ThoughtPayload) => void | Promise<void>;
+  onConnected?: () => void;
+  onDisconnect?: (reason: string) => void;
+  onAuthError?: (status: 401 | 403) => void;
+};
+
+export type FetchForStream = (input: string, init: RequestInit) => Promise<Response>;
+
+export type CreateThoughtStreamOptions = {
+  readonly config: MusubiConfig;
+  readonly agentId?: string;
+  readonly fetch?: FetchForStream;
+  readonly dedup?: BoundedDedupSet;
+  readonly persistence?: LastEventIdStore;
+  readonly random?: () => number;
+  readonly sleep?: (ms: number) => Promise<void>;
+  readonly now?: () => number;
+  /** Default 60s — 2× the spec's 30s ping interval. */
+  readonly pingTimeoutMs?: number;
+  /** Reset backoff attempt counter after this much stable connection. */
+  readonly stableResetMs?: number;
+  /** Override `include` query param. Default omitted (server applies default). */
+  readonly include?: string;
+};
+
+export type ThoughtStream = {
+  start(handlers: ThoughtStreamHandlers): Promise<void>;
+  stop(): Promise<void>;
+  isRunning(): boolean;
+  /** Test-only inspection. */
+  __backoffAttempt(): number;
+};
+
+const DEFAULT_PING_TIMEOUT_MS = 60_000;
+const DEFAULT_STABLE_RESET_MS = 5 * 60_000;
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export function createThoughtStream(options: CreateThoughtStreamOptions): ThoughtStream {
+  const { config } = options;
+  const fetch = options.fetch ?? ((input, init) => globalThis.fetch(input, init));
+  const dedup = options.dedup ?? new BoundedDedupSet();
+  const persistence = options.persistence ?? new InMemoryLastEventIdStore();
+  const random = options.random ?? Math.random;
+  const sleep = options.sleep ?? defaultSleep;
+  const now = options.now ?? Date.now;
+  const pingTimeoutMs = options.pingTimeoutMs ?? DEFAULT_PING_TIMEOUT_MS;
+  const stableResetMs = options.stableResetMs ?? DEFAULT_STABLE_RESET_MS;
+  const baseUrl = config.core.baseUrl.replace(/\/+$/, "");
+
+  let running = false;
+  let abortController: AbortController | undefined;
+  let attempt = 0;
+
+  const stream: ThoughtStream = {
+    isRunning: () => running,
+    __backoffAttempt: () => attempt,
+
+    async stop() {
+      running = false;
+      abortController?.abort();
+    },
+
+    async start(handlers) {
+      if (running) return;
+      running = true;
+      attempt = 0;
+
+      let presence;
+      try {
+        presence = resolvePresence(config, { agentId: options.agentId });
+      } catch {
+        running = false;
+        return;
+      }
+
+      const url = buildStreamUrl(baseUrl, presence.presence, options.include);
+
+      while (running) {
+        const connectedAtCandidate = now();
+        const outcome = await runOneConnection({
+          url,
+          token: presence.token,
+          fetch,
+          dedup,
+          persistence,
+          pingTimeoutMs,
+          handlers,
+          getRunning: () => running,
+          setAbortController: (c) => {
+            abortController = c;
+          },
+        });
+
+        if (outcome.kind === "auth-fail") {
+          handlers.onAuthError?.(outcome.status);
+          handlers.onDisconnect?.(`auth-${outcome.status}`);
+          running = false;
+          return;
+        }
+
+        if (!running) {
+          handlers.onDisconnect?.("stopped");
+          return;
+        }
+
+        handlers.onDisconnect?.(outcome.kind);
+
+        const stableDuration = now() - connectedAtCandidate;
+        if (outcome.connected && stableDuration >= stableResetMs) {
+          attempt = 0;
+        }
+
+        const delayMs =
+          outcome.kind === "close" && outcome.reconnectAfterMs !== undefined
+            ? outcome.reconnectAfterMs
+            : nextSseBackoffMs(attempt, { random });
+        attempt += 1;
+
+        await sleep(delayMs);
+      }
+    },
+  };
+
+  return stream;
+}
+
+function buildStreamUrl(baseUrl: string, presence: string, include?: string): string {
+  const params = new URLSearchParams({ namespace: presence });
+  if (include !== undefined) params.set("include", include);
+  return `${baseUrl}/v1/thoughts/stream?${params.toString()}`;
+}
+
+type ConnectionOutcome =
+  | { kind: "auth-fail"; status: 401 | 403; connected: false }
+  | { kind: "http-error"; status: number; connected: false }
+  | { kind: "network-error"; connected: false }
+  | { kind: "stream-error"; connected: true }
+  | { kind: "ping-gap-timeout"; connected: true }
+  | { kind: "ended"; connected: true }
+  | { kind: "close"; connected: true; reconnectAfterMs: number | undefined };
+
+type ConnectionContext = {
+  url: string;
+  token: string;
+  fetch: FetchForStream;
+  dedup: BoundedDedupSet;
+  persistence: LastEventIdStore;
+  pingTimeoutMs: number;
+  handlers: ThoughtStreamHandlers;
+  getRunning: () => boolean;
+  setAbortController: (controller: AbortController) => void;
+};
+
+async function runOneConnection(ctx: ConnectionContext): Promise<ConnectionOutcome> {
+  const controller = new AbortController();
+  ctx.setAbortController(controller);
+
+  let pingTimer: ReturnType<typeof setTimeout> | undefined;
+  let pingGapTriggered = false;
+  const resetPingTimer = () => {
+    if (pingTimer) clearTimeout(pingTimer);
+    pingTimer = setTimeout(() => {
+      pingGapTriggered = true;
+      controller.abort();
+    }, ctx.pingTimeoutMs);
+  };
+
+  const lastSeenId = await ctx.persistence.read();
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${ctx.token}`,
+    Accept: "text/event-stream",
+    "Cache-Control": "no-cache",
+  };
+  if (lastSeenId !== undefined) {
+    headers["Last-Event-ID"] = lastSeenId;
+  }
+
+  let response: Response;
+  try {
+    response = await ctx.fetch(ctx.url, {
+      method: "GET",
+      headers,
+      signal: controller.signal,
+    });
+  } catch {
+    if (pingTimer) clearTimeout(pingTimer);
+    return { kind: "network-error", connected: false };
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    if (pingTimer) clearTimeout(pingTimer);
+    return { kind: "auth-fail", status: response.status as 401 | 403, connected: false };
+  }
+  if (!response.ok || !response.body) {
+    if (pingTimer) clearTimeout(pingTimer);
+    return { kind: "http-error", status: response.status, connected: false };
+  }
+
+  resetPingTimer();
+  ctx.handlers.onConnected?.();
+
+  try {
+    for await (const frame of parseSseStream(response.body)) {
+      resetPingTimer();
+      if (!ctx.getRunning()) {
+        return { kind: "ended", connected: true };
+      }
+
+      if (frame.event === "thought") {
+        const thought = safeJsonParse<ThoughtPayload>(frame.data);
+        if (thought === undefined) continue;
+        const id = frame.id ?? thought.object_id;
+        if (ctx.dedup.add(id)) {
+          await ctx.handlers.onThought(thought);
+          await ctx.persistence.write(id);
+        }
+      } else if (frame.event === "close") {
+        const data = safeJsonParse<{ reconnect_after_ms?: number }>(frame.data);
+        return {
+          kind: "close",
+          connected: true,
+          reconnectAfterMs: data?.reconnect_after_ms,
+        };
+      }
+      // Pings just reset the timer (already done above).
+    }
+    return { kind: "ended", connected: true };
+  } catch {
+    if (pingGapTriggered) {
+      return { kind: "ping-gap-timeout", connected: true };
+    }
+    return { kind: "stream-error", connected: true };
+  } finally {
+    if (pingTimer) clearTimeout(pingTimer);
+  }
+}
+
+type SseFrame = { readonly event: string; readonly id: string | undefined; readonly data: string };
+
+async function* parseSseStream(body: ReadableStream<Uint8Array>): AsyncGenerator<SseFrame> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let event = "";
+  let id: string | undefined;
+  let dataLines: string[] = [];
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        if (buffer.length > 0) {
+          buffer += "\n\n";
+        }
+      }
+      if (value !== undefined) {
+        buffer += decoder.decode(value, { stream: !done });
+      }
+
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (line === "") {
+          if (dataLines.length > 0 || event !== "") {
+            yield { event: event || "message", id, data: dataLines.join("\n") };
+          }
+          event = "";
+          id = undefined;
+          dataLines = [];
+          continue;
+        }
+        if (line.startsWith(":")) {
+          continue; // SSE comment
+        }
+        if (line.startsWith("event:")) {
+          event = line.slice(6).replace(/^ /, "");
+        } else if (line.startsWith("id:")) {
+          id = line.slice(3).replace(/^ /, "");
+        } else if (line.startsWith("data:")) {
+          dataLines.push(line.slice(5).replace(/^ /, ""));
+        }
+        // Other field names (retry:) are accepted by spec but unused here.
+      }
+
+      if (done) break;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function safeJsonParse<T>(raw: string): T | undefined {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return undefined;
+  }
+}

--- a/tests/thoughts/backoff.test.ts
+++ b/tests/thoughts/backoff.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { nextSseBackoffMs } from "../../src/thoughts/backoff.js";
+
+describe("nextSseBackoffMs", () => {
+  it("test_stream_reconnects_with_exponential_backoff_jitter_on_drop", () => {
+    // Pure-exponential progression with random pinned to 0 (no jitter):
+    // 1s, 2s, 4s, 8s, 16s, 32s, then capped at 60s.
+    const noJitter = () => 0;
+    expect(nextSseBackoffMs(0, { random: noJitter })).toBe(1_000);
+    expect(nextSseBackoffMs(1, { random: noJitter })).toBe(2_000);
+    expect(nextSseBackoffMs(2, { random: noJitter })).toBe(4_000);
+    expect(nextSseBackoffMs(3, { random: noJitter })).toBe(8_000);
+    expect(nextSseBackoffMs(4, { random: noJitter })).toBe(16_000);
+    expect(nextSseBackoffMs(5, { random: noJitter })).toBe(32_000);
+    expect(nextSseBackoffMs(6, { random: noJitter })).toBe(60_000);
+    expect(nextSseBackoffMs(20, { random: noJitter })).toBe(60_000);
+
+    // Full-jitter (~1s extra) below the cap:
+    const fullJitter = () => 0.999_999;
+    const j0 = nextSseBackoffMs(0, { random: fullJitter });
+    expect(j0).toBeGreaterThan(1_999);
+    expect(j0).toBeLessThan(2_001);
+    expect(nextSseBackoffMs(20, { random: fullJitter })).toBe(60_000); // still capped
+  });
+
+  it("rejects negative attempts", () => {
+    expect(() => nextSseBackoffMs(-1)).toThrowError(RangeError);
+  });
+
+  it("respects custom maxDelayMs override", () => {
+    const noJitter = () => 0;
+    expect(nextSseBackoffMs(20, { maxDelayMs: 5_000, random: noJitter })).toBe(5_000);
+  });
+});

--- a/tests/thoughts/dedup.test.ts
+++ b/tests/thoughts/dedup.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { BoundedDedupSet, DEFAULT_DEDUP_MAX_SIZE } from "../../src/thoughts/dedup.js";
+
+describe("BoundedDedupSet", () => {
+  it("test_stream_dedup_set_caps_at_1000_entries_or_1h_ttl", () => {
+    // Default cap is 1000 per the spec rule.
+    expect(DEFAULT_DEDUP_MAX_SIZE).toBe(1_000);
+
+    const dedup = new BoundedDedupSet({ maxSize: 3, now: () => 100 });
+    expect(dedup.add("a")).toBe(true);
+    expect(dedup.add("b")).toBe(true);
+    expect(dedup.add("c")).toBe(true);
+    expect(dedup.size()).toBe(3);
+
+    // Adding a fourth evicts the oldest (a).
+    expect(dedup.add("d")).toBe(true);
+    expect(dedup.size()).toBe(3);
+    expect(dedup.has("a")).toBe(false);
+    expect(dedup.has("d")).toBe(true);
+  });
+
+  it("test_stream_skips_events_already_in_dedup_set", () => {
+    const dedup = new BoundedDedupSet();
+    expect(dedup.add("ksuid-1")).toBe(true);
+    expect(dedup.add("ksuid-1")).toBe(false);
+    expect(dedup.has("ksuid-1")).toBe(true);
+    expect(dedup.size()).toBe(1);
+  });
+
+  it("expires entries past TTL", () => {
+    let nowValue = 1_000;
+    const dedup = new BoundedDedupSet({
+      ttlMs: 100,
+      now: () => nowValue,
+    });
+
+    dedup.add("ephemeral");
+    expect(dedup.has("ephemeral")).toBe(true);
+
+    nowValue += 50;
+    expect(dedup.has("ephemeral")).toBe(true);
+
+    nowValue += 100;
+    expect(dedup.has("ephemeral")).toBe(false);
+    expect(dedup.size()).toBe(0);
+  });
+});

--- a/tests/thoughts/persistence.test.ts
+++ b/tests/thoughts/persistence.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { InMemoryLastEventIdStore } from "../../src/thoughts/persistence.js";
+
+describe("InMemoryLastEventIdStore", () => {
+  it("test_stream_persists_last_event_id_across_restart", async () => {
+    // First "session" — write the last seen id.
+    const session1 = new InMemoryLastEventIdStore();
+    await session1.write("ksuid-abc-123");
+    const persistedValue = await session1.read();
+
+    // Simulate restart by constructing a new store seeded from the persisted value.
+    // Production stores (IndexedDB / chrome.storage / file / KV) survive
+    // process restarts; the in-memory variant simulates by passing the value
+    // explicitly into the new instance.
+    const session2 = new InMemoryLastEventIdStore(persistedValue);
+    expect(await session2.read()).toBe("ksuid-abc-123");
+  });
+
+  it("returns undefined when nothing has been written", async () => {
+    const store = new InMemoryLastEventIdStore();
+    expect(await store.read()).toBeUndefined();
+  });
+
+  it("clear() resets the stored value", async () => {
+    const store = new InMemoryLastEventIdStore("ksuid-x");
+    await store.clear();
+    expect(await store.read()).toBeUndefined();
+  });
+
+  it("write() overwrites the previous value", async () => {
+    const store = new InMemoryLastEventIdStore("old");
+    await store.write("new");
+    expect(await store.read()).toBe("new");
+  });
+});

--- a/tests/thoughts/stream.test.ts
+++ b/tests/thoughts/stream.test.ts
@@ -1,0 +1,556 @@
+import { describe, it, expect } from "vitest";
+import { createThoughtStream, type ThoughtPayload } from "../../src/thoughts/stream.js";
+import type { FetchForStream } from "../../src/thoughts/stream.js";
+import { BoundedDedupSet } from "../../src/thoughts/dedup.js";
+import { InMemoryLastEventIdStore } from "../../src/thoughts/persistence.js";
+import type { MusubiConfig } from "../../src/config.js";
+
+function makeConfig(overrides: Partial<MusubiConfig> = {}): MusubiConfig {
+  return {
+    core: { baseUrl: "https://musubi.test", token: "t", ...(overrides.core ?? {}) },
+    presence: { defaultId: "eric/openclaw", ...(overrides.presence ?? {}) },
+  };
+}
+
+type ScriptedSseAction =
+  | { type: "frames"; text: string }
+  | { type: "delay"; ms: number }
+  | { type: "close" }
+  | { type: "abort" };
+
+type ScriptedResponse =
+  | { status: 200; actions: ScriptedSseAction[] }
+  | { status: number }
+  | { throw: Error };
+
+type RecordedRequest = {
+  url: string;
+  headers: Record<string, string>;
+};
+
+function streamFromActions(
+  actions: ScriptedSseAction[],
+  signal: AbortSignal,
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      if (signal.aborted) {
+        controller.error(new DOMException("aborted", "AbortError"));
+        return;
+      }
+      const abortListener = () => {
+        try {
+          controller.error(new DOMException("aborted", "AbortError"));
+        } catch {
+          // already closed
+        }
+      };
+      signal.addEventListener("abort", abortListener, { once: true });
+
+      try {
+        for (const action of actions) {
+          if (signal.aborted) return;
+          if (action.type === "frames") {
+            controller.enqueue(encoder.encode(action.text));
+          } else if (action.type === "delay") {
+            await new Promise((resolve) => setTimeout(resolve, action.ms));
+          } else if (action.type === "close") {
+            controller.close();
+            return;
+          } else if (action.type === "abort") {
+            controller.error(new Error("network blip"));
+            return;
+          }
+        }
+        controller.close();
+      } finally {
+        signal.removeEventListener("abort", abortListener);
+      }
+    },
+  });
+}
+
+function createMockFetch(script: ScriptedResponse[]): {
+  fetch: FetchForStream;
+  requests: RecordedRequest[];
+} {
+  const requests: RecordedRequest[] = [];
+  let cursor = 0;
+  const fetch: FetchForStream = async (url, init) => {
+    const headers: Record<string, string> = {};
+    if (init.headers) {
+      for (const [k, v] of Object.entries(init.headers as Record<string, string>)) {
+        headers[k] = v;
+      }
+    }
+    requests.push({ url, headers });
+
+    const def = script[cursor] ?? script[script.length - 1];
+    cursor += 1;
+    if (def === undefined) throw new Error("script exhausted");
+
+    if ("throw" in def) throw def.throw;
+
+    if (def.status === 200 && "actions" in def) {
+      const signal = init.signal as AbortSignal;
+      const body = streamFromActions(def.actions, signal);
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    }
+
+    return new Response(null, { status: def.status });
+  };
+  return { fetch, requests };
+}
+
+function frame(event: string, id: string | undefined, data: unknown): string {
+  const parts = [`event: ${event}`];
+  if (id !== undefined) parts.push(`id: ${id}`);
+  parts.push(`data: ${typeof data === "string" ? data : JSON.stringify(data)}`);
+  parts.push("");
+  parts.push("");
+  return parts.join("\n");
+}
+
+function makeThoughtFrame(overrides: Partial<ThoughtPayload> & { object_id: string }): string {
+  const payload: ThoughtPayload = {
+    object_id: overrides.object_id,
+    from_presence: overrides.from_presence ?? "eric/claude-code",
+    to_presence: overrides.to_presence ?? "openclaw",
+    namespace: overrides.namespace ?? "eric/openclaw",
+    content: overrides.content ?? "hello",
+    sent_at: overrides.sent_at ?? "2026-04-20T00:00:00.000Z",
+    ...(overrides.channel !== undefined ? { channel: overrides.channel } : {}),
+    ...(overrides.importance !== undefined ? { importance: overrides.importance } : {}),
+  };
+  return frame("thought", overrides.object_id, payload);
+}
+
+async function wait(ms = 0): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("createThoughtStream", () => {
+  it("test_stream_accepts_thought_ping_close_events", async () => {
+    const receivedThoughts: ThoughtPayload[] = [];
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        actions: [
+          { type: "frames", text: makeThoughtFrame({ object_id: "k1", content: "first" }) },
+          { type: "frames", text: frame("ping", undefined, { at: "2026-04-20T00:00:30Z" }) },
+          { type: "frames", text: makeThoughtFrame({ object_id: "k2", content: "second" }) },
+          { type: "frames", text: frame("close", undefined, { reason: "server-shutdown" }) },
+          { type: "close" },
+        ],
+      },
+      { throw: new TypeError("no more responses") },
+    ]);
+
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch,
+      sleep: async () => undefined,
+      random: () => 0,
+    });
+
+    const startPromise = stream.start({
+      onThought: (t) => {
+        receivedThoughts.push(t);
+        if (receivedThoughts.length === 2) void stream.stop();
+      },
+    });
+
+    await Promise.race([startPromise, wait(500)]);
+    await stream.stop();
+    await startPromise;
+
+    expect(receivedThoughts).toHaveLength(2);
+    expect(receivedThoughts[0]?.content).toBe("first");
+    expect(receivedThoughts[1]?.content).toBe("second");
+  });
+
+  it("test_stream_does_not_reconnect_on_403", async () => {
+    const { fetch, requests } = createMockFetch([
+      { status: 403 },
+      { status: 200, actions: [{ type: "close" }] }, // should never reach
+    ]);
+
+    const authErrors: number[] = [];
+    const disconnects: string[] = [];
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch,
+      sleep: async () => undefined,
+      random: () => 0,
+    });
+
+    await stream.start({
+      onThought: () => undefined,
+      onAuthError: (status) => authErrors.push(status),
+      onDisconnect: (reason) => disconnects.push(reason),
+    });
+
+    expect(authErrors).toEqual([403]);
+    expect(disconnects).toEqual(["auth-403"]);
+    expect(requests).toHaveLength(1); // no reconnect
+    expect(stream.isRunning()).toBe(false);
+  });
+
+  it("test_stream_surfaces_403_as_auth_required_status", async () => {
+    const { fetch } = createMockFetch([{ status: 403 }]);
+
+    let surfaced: number | undefined;
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch,
+      sleep: async () => undefined,
+      random: () => 0,
+    });
+
+    await stream.start({
+      onThought: () => undefined,
+      onAuthError: (status) => {
+        surfaced = status;
+      },
+    });
+
+    expect(surfaced).toBe(403);
+  });
+
+  it("test_stream_sits_in_reconnect_when_endpoint_returns_404", async () => {
+    const sleepCalls: number[] = [];
+    const { fetch, requests } = createMockFetch([
+      { status: 404 },
+      { status: 404 },
+      {
+        status: 200,
+        actions: [
+          { type: "frames", text: makeThoughtFrame({ object_id: "k1" }) },
+          { type: "close" },
+        ],
+      },
+    ]);
+
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch,
+      sleep: async (ms) => {
+        sleepCalls.push(ms);
+      },
+      random: () => 0,
+    });
+
+    await stream.start({
+      onThought: () => {
+        void stream.stop();
+      },
+    });
+
+    expect(requests.length).toBeGreaterThanOrEqual(3);
+    // First two are pure exponential 1000, 2000 with no-jitter.
+    expect(sleepCalls[0]).toBe(1_000);
+    expect(sleepCalls[1]).toBe(2_000);
+    expect(stream.isRunning()).toBe(false);
+  });
+
+  it("test_stream_resumes_with_last_event_id_header_on_reconnect", async () => {
+    const { fetch, requests } = createMockFetch([
+      {
+        status: 200,
+        actions: [
+          { type: "frames", text: makeThoughtFrame({ object_id: "ksuid-first" }) },
+          { type: "close" },
+        ],
+      },
+      {
+        status: 200,
+        actions: [
+          { type: "frames", text: makeThoughtFrame({ object_id: "ksuid-second" }) },
+          { type: "close" },
+        ],
+      },
+      { throw: new TypeError("stop here") },
+    ]);
+
+    const persistence = new InMemoryLastEventIdStore();
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch,
+      persistence,
+      sleep: async () => undefined,
+      random: () => 0,
+    });
+
+    const received: string[] = [];
+    await stream.start({
+      onThought: (t) => {
+        received.push(t.object_id);
+        if (received.length === 2) void stream.stop();
+      },
+    });
+
+    // First request has no Last-Event-ID; second does (the id from first frame).
+    expect(requests[0]?.headers["Last-Event-ID"]).toBeUndefined();
+    expect(requests[1]?.headers["Last-Event-ID"]).toBe("ksuid-first");
+    expect(await persistence.read()).toBe("ksuid-second");
+  });
+
+  it("test_stream_honors_close_event_reconnect_after_ms_hint", async () => {
+    const sleepCalls: number[] = [];
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        actions: [
+          {
+            type: "frames",
+            text: frame("close", undefined, { reconnect_after_ms: 5_000 }),
+          },
+          { type: "close" },
+        ],
+      },
+      {
+        status: 200,
+        actions: [
+          { type: "frames", text: makeThoughtFrame({ object_id: "k1" }) },
+          { type: "close" },
+        ],
+      },
+    ]);
+
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch,
+      sleep: async (ms) => {
+        sleepCalls.push(ms);
+      },
+      random: () => 0,
+    });
+
+    await stream.start({
+      onThought: () => {
+        void stream.stop();
+      },
+    });
+
+    expect(sleepCalls[0]).toBe(5_000);
+  });
+
+  it("test_stream_compares_object_ids_lexicographically", async () => {
+    // KSUIDs are 27-char base62, lex-sorted by time. Client persists the
+    // *most recently received* id. We verify that the persisted id is
+    // stored as a string (comparable lexicographically), not parsed into
+    // a number or otherwise munged.
+    const persistence = new InMemoryLastEventIdStore();
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        actions: [
+          { type: "frames", text: makeThoughtFrame({ object_id: "2iVVRLuAh_aaaaaaaaaaaaaaaa" }) },
+          { type: "frames", text: makeThoughtFrame({ object_id: "2iVVRLuCj_bbbbbbbbbbbbbbbb" }) },
+          { type: "close" },
+        ],
+      },
+      { throw: new TypeError("stop") },
+    ]);
+
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch,
+      persistence,
+      sleep: async () => undefined,
+      random: () => 0,
+    });
+
+    let seen = 0;
+    await stream.start({
+      onThought: () => {
+        seen += 1;
+        if (seen === 2) void stream.stop();
+      },
+    });
+
+    const persisted = await persistence.read();
+    expect(typeof persisted).toBe("string");
+    // "C" > "A" lexicographically in base62; the most recent id should be
+    // the later KSUID when compared as strings.
+    expect(persisted! > "2iVVRLuAh_aaaaaaaaaaaaaaaa").toBe(true);
+    expect(persisted).toBe("2iVVRLuCj_bbbbbbbbbbbbbbbb");
+  });
+
+  it("test_stream_dedups_across_multiple_concurrent_subscribers_for_same_presence", async () => {
+    // Broadcast fanout means two subscribers for the same presence see the
+    // same events. The in-process dedup set guarantees a single consumer
+    // never delivers a duplicate, even if the server replays an id on
+    // reconnect overlap.
+    const sharedDedup = new BoundedDedupSet();
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        actions: [
+          { type: "frames", text: makeThoughtFrame({ object_id: "k1", content: "first" }) },
+          { type: "frames", text: makeThoughtFrame({ object_id: "k1", content: "first-again" }) },
+          { type: "frames", text: makeThoughtFrame({ object_id: "k2", content: "second" }) },
+          { type: "close" },
+        ],
+      },
+      { throw: new TypeError("stop") },
+    ]);
+
+    const received: string[] = [];
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch,
+      dedup: sharedDedup,
+      sleep: async () => undefined,
+      random: () => 0,
+    });
+
+    await stream.start({
+      onThought: (t) => {
+        received.push(t.content);
+        if (received.length === 2) void stream.stop();
+      },
+    });
+
+    expect(received).toEqual(["first", "second"]);
+  });
+
+  it("test_stream_closes_client_side_when_no_frame_in_60s", async () => {
+    // Use a tiny ping timeout so the test runs in milliseconds.
+    const { fetch, requests } = createMockFetch([
+      {
+        status: 200,
+        actions: [
+          // Connection opens but never sends any frame, even a ping.
+          { type: "delay", ms: 200 },
+          { type: "close" },
+        ],
+      },
+      { status: 200, actions: [{ type: "close" }] },
+    ]);
+
+    const disconnects: string[] = [];
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch,
+      sleep: async () => undefined,
+      random: () => 0,
+      pingTimeoutMs: 20, // trip fast
+    });
+
+    const startPromise = stream.start({
+      onThought: () => undefined,
+      onDisconnect: (reason) => {
+        disconnects.push(reason);
+        if (disconnects.length >= 1) void stream.stop();
+      },
+    });
+
+    await Promise.race([startPromise, wait(500)]);
+    await stream.stop();
+    await startPromise;
+
+    expect(disconnects).toContain("ping-gap-timeout");
+    expect(requests.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("test_stream_backoff_resets_after_5_minutes_stable", async () => {
+    // Simulate a connection that's stable for 5+ minutes, then drops. The
+    // next backoff should be the attempt-0 delay (1s no-jitter), not the
+    // accumulated attempt counter's delay.
+    //
+    // Strategy: advance a virtual clock inside the onThought callback so
+    // the stream sees `connectedAtCandidate` from before the frame and
+    // `now()` from after the 5-minute mark when computing stableDuration.
+    let virtualNow = 0;
+    const sleepCalls: number[] = [];
+    const { fetch } = createMockFetch([
+      // First connection: immediate drop, increments attempt to 1.
+      { status: 200, actions: [{ type: "abort" }] },
+      // Second connection: delivers one thought, then closes. During the
+      // thought handler we jump the virtual clock past the reset window.
+      {
+        status: 200,
+        actions: [
+          { type: "frames", text: makeThoughtFrame({ object_id: "k1" }) },
+          { type: "close" },
+        ],
+      },
+      // Third connection: stop after first frame so the test can assert
+      // the sleep that preceded this connection.
+      {
+        status: 200,
+        actions: [
+          { type: "frames", text: makeThoughtFrame({ object_id: "k2" }) },
+          { type: "close" },
+        ],
+      },
+    ]);
+
+    let seen = 0;
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch,
+      sleep: async (ms) => {
+        sleepCalls.push(ms);
+      },
+      now: () => virtualNow,
+      random: () => 0,
+      stableResetMs: 300_000,
+    });
+
+    await stream.start({
+      onThought: () => {
+        seen += 1;
+        if (seen === 1) {
+          // Jump past the reset window while the connection is still
+          // "in progress" — stableDuration will exceed stableResetMs when
+          // this connection ends.
+          virtualNow += 400_000;
+        }
+        if (seen === 2) void stream.stop();
+      },
+    });
+
+    // After the first drop (attempt 0 used): sleep is 1s.
+    expect(sleepCalls[0]).toBe(1_000);
+    // After the second connection's drop: stableDuration > stableResetMs,
+    // so attempt was reset to 0, so sleep is again 1s.
+    expect(sleepCalls[1]).toBe(1_000);
+  });
+
+  it("stop() aborts an in-flight connection and prevents further reconnects", async () => {
+    const { fetch, requests } = createMockFetch([
+      {
+        status: 200,
+        actions: [
+          { type: "frames", text: makeThoughtFrame({ object_id: "k1" }) },
+          { type: "delay", ms: 10_000 }, // hang
+          { type: "close" },
+        ],
+      },
+      { status: 200, actions: [{ type: "close" }] },
+    ]);
+
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch,
+      sleep: async () => undefined,
+      random: () => 0,
+    });
+
+    const startPromise = stream.start({
+      onThought: () => {
+        void stream.stop();
+      },
+    });
+
+    await startPromise;
+    expect(stream.isRunning()).toBe(false);
+    expect(requests.length).toBe(1); // no reconnect after stop
+  });
+});


### PR DESCRIPTION
## Summary

Real-time thought delivery via Musubi's `GET /v1/thoughts/stream` — the SSE endpoint shipped upstream in [musubi#106](https://github.com/ericmey/musubi/pull/106).

## Slice

Closes #7. Unblocked by upstream `slice-api-thoughts-stream` (merged to v2).

## Implementation

Four composable modules:

- `src/thoughts/backoff.ts` — `nextSseBackoffMs` matching spec formula `min(2^n * 1000ms + rand(0, 1000ms), 60s)`.
- `src/thoughts/dedup.ts` — `BoundedDedupSet` (1000 / 1h bounds, Map insertion-order eviction).
- `src/thoughts/persistence.ts` — `LastEventIdStore` interface + `InMemoryLastEventIdStore`.
- `src/thoughts/stream.ts` — reconnect loop + zero-dep SSE parser tying them together.

## Six consumer-expectation rules (all green)

Per `docs/api-contract.md` §SSE mirroring upstream canonical-api:

1. **Exponential backoff with jitter** on drop, reset after 5 min stable
2. **Persist Last-Event-ID** across restarts (abstraction lets consumers pick IndexedDB / chrome.storage / file / KV)
3. **Bounded dedup set** (1000 entries or 1h TTL)
4. **403 does NOT reconnect** — surfaces as `onAuthError`, stops the loop
5. **Ping-gap timeout** (60s = 2× ping interval) aborts dead connections
6. **Lex string comparison** for KSUID `object_id`

Plus broadcast-fanout safety: concurrent subscribers for the same presence share dedup state so replay + in-flight overlap never double-delivers.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm format:check\` clean
- [x] \`pnpm test\` — **86/86**
- [x] \`pnpm build\` clean
- [x] All 14 named contract tests present and green

## Docs

- [x] \`CHANGELOG.md\` updated
- [ ] No contract change beyond what api-contract.md already specifies

## Upstream coordination

Upstream endpoint shipped in `musubi#106`. Verified against `src/musubi/api/routers/thoughts.py` and `docs/architecture/07-interfaces/canonical-api.md` §5 in the current v2 HEAD. Note: upstream's `Last-Event-ID` replay is "deferred to integration harness" in today's build — the header is accepted but server currently starts from live-tail. No client change needed when replay lands; we send the header regardless.