### PR TITLE
Slice #8: agent-tools (musubi_recall, musubi_remember, musubi_think)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to a calendar-flavored semantic versioning scheme
 
 ### Added
 
+- Three agent-callable tools in `src/tools/`:
+  - `createRecallTool(...)` → `musubi_recall` — deep-path retrieve across
+    all planes with full hybrid + rerank.
+  - `createRememberTool(...)` → `musubi_remember` — explicit episodic
+    capture at importance 7 (above passive capture's 5), optional
+    client-supplied idempotency key.
+  - `createThinkTool(...)` → `musubi_think` — presence-to-presence
+    thought send; recipient sees it in real-time via the SSE stream.
+  Each factory returns `{ definition, recommendedOptional: true }` — the
+  wiring slice passes `{ optional: true }` to `api.registerTool(...)`.
+- TypeBox parameter schemas in `src/tools/parameters.ts`.
 - `createThoughtStream({ config, ... })` in `src/thoughts/stream.ts` — SSE
   consumer for `GET /v1/thoughts/stream` with all six consumer-expectation
   rules: exponential backoff with jitter, persisted `Last-Event-ID`,

--- a/src/tools/parameters.ts
+++ b/src/tools/parameters.ts
@@ -1,0 +1,93 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+/**
+ * TypeBox schemas for the three agent-callable Musubi tools. The wiring
+ * slice passes these to OpenClaw's `api.registerTool(...)` (typebox
+ * schemas are what the plugin SDK's Quick Start example uses — see
+ * `docs/plugins/building-plugins.md`).
+ */
+
+export const PLANE_ENUM = ["curated", "concept", "episodic", "artifact"] as const;
+
+export const RecallParameters = Type.Object(
+  {
+    query: Type.String({
+      minLength: 1,
+      description: "Natural-language query to search Musubi with.",
+    }),
+    planes: Type.Optional(
+      Type.Array(Type.Union(PLANE_ENUM.map((p) => Type.Literal(p))), {
+        description:
+          "Restrict results to specific planes. Default: all four. Use [curated, concept] for facts, [episodic] for conversation history.",
+      }),
+    ),
+    limit: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        maximum: 50,
+        description: "Max rows to return. Defaults to 10.",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export const RememberParameters = Type.Object(
+  {
+    content: Type.String({
+      minLength: 1,
+      description: "The thing worth remembering. One fact or observation per call.",
+    }),
+    importance: Type.Optional(
+      Type.Integer({
+        minimum: 0,
+        maximum: 10,
+        description:
+          "Importance hint 0-10. Default 7 (agents explicitly remembering is higher-signal than passive capture).",
+      }),
+    ),
+    topics: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Topic tags for later filtering.",
+      }),
+    ),
+    idempotencyKey: Type.Optional(
+      Type.String({
+        description:
+          "Override the auto-generated idempotency key. Use when the agent has a stable client-side id for the thing being remembered.",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export const ThinkParameters = Type.Object(
+  {
+    toPresence: Type.String({
+      minLength: 1,
+      description:
+        "Destination presence id, e.g. 'eric/claude-code' or 'eric/rin'. Use 'all' to broadcast.",
+    }),
+    content: Type.String({
+      minLength: 1,
+      description: "The message to send to the other presence.",
+    }),
+    channel: Type.Optional(
+      Type.String({
+        description: "Optional channel name. Defaults to the configured channel.",
+      }),
+    ),
+    importance: Type.Optional(
+      Type.Integer({
+        minimum: 0,
+        maximum: 10,
+        description: "Priority hint 0-10. Default 5.",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export type RecallParams = Static<typeof RecallParameters>;
+export type RememberParams = Static<typeof RememberParameters>;
+export type ThinkParams = Static<typeof ThinkParameters>;

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -1,0 +1,126 @@
+import type { MusubiConfig } from "../config.js";
+import type { MusubiClient } from "../musubi/client.js";
+import { MusubiError } from "../musubi/errors.js";
+import { resolvePresence } from "../presence/resolver.js";
+import { RecallParameters, type RecallParams } from "./parameters.js";
+
+/**
+ * Agent-callable deep-path retrieval across all planes.
+ *
+ * The passive `MemoryCorpusSupplement` from slice #4 covers the common
+ * case (query-relevant curated + concept rows in fast mode). `recall` is
+ * the explicit escape hatch when the supplement missed, or when the
+ * agent knows it wants the full hybrid + rerank pipeline across every
+ * plane including episodic and artifacts.
+ */
+
+export type ToolDefinition = {
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: typeof RecallParameters;
+  execute(toolCallId: string, params: RecallParams): Promise<ToolResult>;
+};
+
+export type ToolResult = {
+  readonly content: ReadonlyArray<{ type: "text"; text: string }>;
+  readonly isError?: boolean;
+};
+
+export type CreateRecallToolOptions = {
+  readonly client: MusubiClient;
+  readonly config: MusubiConfig;
+  /** OpenClaw agent id for presence resolution. */
+  readonly agentId?: string;
+};
+
+export type RecallTool = {
+  readonly definition: ToolDefinition;
+  /** Hint to the wiring slice: this tool is opt-in per-agent, not required. */
+  readonly recommendedOptional: true;
+};
+
+const DEFAULT_LIMIT = 10;
+
+type MusubiRetrieveRow = {
+  readonly object_id: string;
+  readonly score: number;
+  readonly plane: string;
+  readonly content: string;
+  readonly namespace: string;
+};
+
+type MusubiRetrieveResponse = {
+  readonly results: readonly MusubiRetrieveRow[];
+};
+
+export function createRecallTool(options: CreateRecallToolOptions): RecallTool {
+  const { client, config, agentId } = options;
+
+  return {
+    recommendedOptional: true,
+    definition: {
+      name: "musubi_recall",
+      description:
+        "Search Musubi across every plane (curated knowledge, synthesized concepts, episodic memory, source artifacts) using the full hybrid + rerank pipeline. Use when the passive memory supplement didn't surface what you need.",
+      parameters: RecallParameters,
+      async execute(_toolCallId, params) {
+        let presence;
+        try {
+          presence = resolvePresence(config, { agentId });
+        } catch (err) {
+          return toolError(`Presence unresolved: ${errorMessage(err)}`);
+        }
+
+        const limit = params.limit ?? DEFAULT_LIMIT;
+        const planes = params.planes ?? ["curated", "concept", "episodic", "artifact"];
+
+        try {
+          const response = await client.post<MusubiRetrieveResponse>("/v1/retrieve", {
+            body: {
+              query_text: params.query,
+              mode: "deep",
+              planes,
+              limit,
+              namespace: presence.presence,
+            },
+          });
+
+          const results = response.results ?? [];
+          if (results.length === 0) {
+            return toolText(`No Musubi results for "${params.query}".`);
+          }
+
+          return toolText(formatResults(results));
+        } catch (err) {
+          return toolError(`Musubi recall failed: ${errorMessage(err)}`);
+        }
+      },
+    },
+  };
+}
+
+function formatResults(rows: readonly MusubiRetrieveRow[]): string {
+  const lines: string[] = [];
+  lines.push(`Musubi returned ${rows.length} result(s):`);
+  lines.push("");
+  for (const row of rows) {
+    lines.push(`[${row.plane}] (score ${row.score.toFixed(2)}) ${row.namespace}/${row.object_id}`);
+    lines.push(row.content);
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd();
+}
+
+function toolText(text: string): ToolResult {
+  return { content: [{ type: "text", text }] };
+}
+
+function toolError(text: string): ToolResult {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof MusubiError) return `${err.name}: ${err.message}`;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/src/tools/remember.ts
+++ b/src/tools/remember.ts
@@ -1,0 +1,103 @@
+import type { MusubiConfig } from "../config.js";
+import type { MusubiClient } from "../musubi/client.js";
+import { MusubiError } from "../musubi/errors.js";
+import { resolvePresence } from "../presence/resolver.js";
+import { RememberParameters, type RememberParams } from "./parameters.js";
+
+/**
+ * Agent-callable explicit episodic capture.
+ *
+ * The capture-mirror from slice #6 passively mirrors `agent_end` events
+ * into Musubi episodic at neutral importance (5). `remember` is the
+ * explicit "this matters" path — higher default importance, optional
+ * topics, and an optional client-supplied idempotency key for when the
+ * agent is recording something with a stable identity (e.g. referencing
+ * an external issue id).
+ */
+
+export type ToolDefinition = {
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: typeof RememberParameters;
+  execute(
+    toolCallId: string,
+    params: RememberParams,
+  ): Promise<{ content: ReadonlyArray<{ type: "text"; text: string }>; isError?: boolean }>;
+};
+
+export type CreateRememberToolOptions = {
+  readonly client: MusubiClient;
+  readonly config: MusubiConfig;
+  readonly agentId?: string;
+  readonly now?: () => Date;
+};
+
+export type RememberTool = {
+  readonly definition: ToolDefinition;
+  readonly recommendedOptional: true;
+};
+
+const DEFAULT_IMPORTANCE = 7;
+const CAPTURE_SOURCE = "openclaw-agent-remember";
+
+export function createRememberTool(options: CreateRememberToolOptions): RememberTool {
+  const { client, config, agentId } = options;
+  const now = options.now ?? (() => new Date());
+
+  return {
+    recommendedOptional: true,
+    definition: {
+      name: "musubi_remember",
+      description:
+        "Explicitly capture something into Musubi's episodic memory. Use for things the agent judges as load-bearing — decisions, facts, commitments, observations. Passive capture already mirrors every turn; use this for higher-signal items.",
+      parameters: RememberParameters,
+      async execute(toolCallId, params) {
+        let presence;
+        try {
+          presence = resolvePresence(config, { agentId });
+        } catch (err) {
+          return errorResult(`Presence unresolved: ${errorMessage(err)}`);
+        }
+
+        const idempotencyKey = params.idempotencyKey ?? `openclaw-remember:${toolCallId}`;
+
+        try {
+          const response = await client.post<{ object_id?: string }>("/v1/episodic", {
+            body: {
+              namespace: presence.namespaces.episodic,
+              content: params.content,
+              capture_source: CAPTURE_SOURCE,
+              source_ref: toolCallId,
+              timestamp: now().toISOString(),
+              importance: params.importance ?? DEFAULT_IMPORTANCE,
+              topics: params.topics ?? [],
+              metadata: {},
+            },
+            idempotencyKey,
+          });
+
+          const storedId = response?.object_id ?? "(no id)";
+          return successResult(
+            `Remembered in Musubi episodic (${presence.namespaces.episodic}) — id ${storedId}.`,
+          );
+        } catch (err) {
+          return errorResult(`Musubi remember failed: ${errorMessage(err)}`);
+        }
+      },
+    },
+  };
+}
+
+function successResult(text: string) {
+  return { content: [{ type: "text" as const, text }] };
+}
+
+function errorResult(text: string) {
+  return { content: [{ type: "text" as const, text }], isError: true };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof MusubiError) return `${err.name}: ${err.message}`;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/src/tools/think.ts
+++ b/src/tools/think.ts
@@ -1,0 +1,94 @@
+import type { MusubiConfig } from "../config.js";
+import type { MusubiClient } from "../musubi/client.js";
+import { MusubiError } from "../musubi/errors.js";
+import { resolvePresence } from "../presence/resolver.js";
+import { ThinkParameters, type ThinkParams } from "./parameters.js";
+
+/**
+ * Agent-callable presence-to-presence thought send.
+ *
+ * "Tell my Claude Code session that the deploy is done" becomes a
+ * concrete `POST /v1/thoughts/send` with `from_presence` derived from
+ * the sending agent's presence context. Recipients receive it in
+ * real-time via the SSE thought-stream (slice #7) — no polling needed.
+ */
+
+export type ToolDefinition = {
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: typeof ThinkParameters;
+  execute(
+    toolCallId: string,
+    params: ThinkParams,
+  ): Promise<{ content: ReadonlyArray<{ type: "text"; text: string }>; isError?: boolean }>;
+};
+
+export type CreateThinkToolOptions = {
+  readonly client: MusubiClient;
+  readonly config: MusubiConfig;
+  readonly agentId?: string;
+};
+
+export type ThinkTool = {
+  readonly definition: ToolDefinition;
+  readonly recommendedOptional: true;
+};
+
+const DEFAULT_CHANNEL = "default";
+const DEFAULT_IMPORTANCE = 5;
+
+export function createThinkTool(options: CreateThinkToolOptions): ThinkTool {
+  const { client, config, agentId } = options;
+
+  return {
+    recommendedOptional: true,
+    definition: {
+      name: "musubi_think",
+      description:
+        "Send a thought to another presence (agent, modality, or human endpoint). The recipient sees it in real-time via their thought stream. Use for cross-modality coordination: tell your CLI session the deploy finished, tell a voice agent to call back later, etc.",
+      parameters: ThinkParameters,
+      async execute(_toolCallId, params) {
+        let presence;
+        try {
+          presence = resolvePresence(config, { agentId });
+        } catch (err) {
+          return errorResult(`Presence unresolved: ${errorMessage(err)}`);
+        }
+
+        try {
+          const response = await client.post<{ object_id?: string }>("/v1/thoughts/send", {
+            body: {
+              from_presence: presence.presence,
+              to_presence: params.toPresence,
+              namespace: presence.presence,
+              content: params.content,
+              channel: params.channel ?? DEFAULT_CHANNEL,
+              importance: params.importance ?? DEFAULT_IMPORTANCE,
+            },
+          });
+
+          const storedId = response?.object_id ?? "(no id)";
+          return successResult(
+            `Thought sent from ${presence.presence} to ${params.toPresence} — id ${storedId}.`,
+          );
+        } catch (err) {
+          return errorResult(`Musubi think failed: ${errorMessage(err)}`);
+        }
+      },
+    },
+  };
+}
+
+function successResult(text: string) {
+  return { content: [{ type: "text" as const, text }] };
+}
+
+function errorResult(text: string) {
+  return { content: [{ type: "text" as const, text }], isError: true };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof MusubiError) return `${err.name}: ${err.message}`;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/tests/tools/recall.test.ts
+++ b/tests/tools/recall.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import { MusubiClient } from "../../src/musubi/client.js";
+import { createRecallTool } from "../../src/tools/recall.js";
+import type { MusubiConfig } from "../../src/config.js";
+import type { FetchLike } from "../../src/musubi/types.js";
+
+function makeConfig(overrides: Partial<MusubiConfig> = {}): MusubiConfig {
+  return {
+    core: { baseUrl: "https://musubi.test", token: "t", ...(overrides.core ?? {}) },
+    presence: { defaultId: "eric/openclaw", ...(overrides.presence ?? {}) },
+  };
+}
+
+type ScriptedResponse = { status: number; body?: unknown } | { throw: Error };
+
+function createMockFetch(script: ScriptedResponse[]) {
+  const calls: Array<{ url: string; body: string | undefined }> = [];
+  let cursor = 0;
+  const fetch: FetchLike = async (url, init) => {
+    calls.push({ url, body: typeof init.body === "string" ? init.body : undefined });
+    const def = script[cursor] ?? script[script.length - 1];
+    cursor += 1;
+    if (def === undefined) throw new Error("script exhausted");
+    if ("throw" in def) throw def.throw;
+    return new Response(def.body !== undefined ? JSON.stringify(def.body) : null, {
+      status: def.status,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return { fetch, calls };
+}
+
+function makeClient(fetch: FetchLike) {
+  return new MusubiClient({
+    baseUrl: "https://musubi.test",
+    token: "t",
+    fetch,
+    sleep: async () => undefined,
+    random: () => 0,
+    generateRequestId: () => "r",
+    generateIdempotencyKey: () => "i",
+    retry: { maxAttempts: 1 },
+  });
+}
+
+describe("createRecallTool", () => {
+  it("test_recall_registered_as_optional_tool_not_required", () => {
+    const { fetch } = createMockFetch([{ status: 200, body: { results: [] } }]);
+    const tool = createRecallTool({ client: makeClient(fetch), config: makeConfig() });
+    expect(tool.recommendedOptional).toBe(true);
+    expect(tool.definition.name).toBe("musubi_recall");
+  });
+
+  it("test_recall_queries_retrieve_with_deep_mode", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: { results: [] } }]);
+    const tool = createRecallTool({ client: makeClient(fetch), config: makeConfig() });
+
+    await tool.definition.execute("call-1", { query: "find the thing" });
+
+    expect(calls[0]?.url).toBe("https://musubi.test/v1/retrieve");
+    const body = JSON.parse(calls[0]!.body!);
+    expect(body.mode).toBe("deep");
+    expect(body.query_text).toBe("find the thing");
+  });
+
+  it("test_recall_accepts_plane_filter_and_limit_parameters", async () => {
+    const { fetch, calls } = createMockFetch([
+      { status: 200, body: { results: [] } },
+      { status: 200, body: { results: [] } },
+    ]);
+    const tool = createRecallTool({ client: makeClient(fetch), config: makeConfig() });
+
+    await tool.definition.execute("c1", { query: "x", planes: ["curated"], limit: 3 });
+    await tool.definition.execute("c2", { query: "x" });
+
+    expect(JSON.parse(calls[0]!.body!).planes).toEqual(["curated"]);
+    expect(JSON.parse(calls[0]!.body!).limit).toBe(3);
+    // Default when unspecified: all four planes, limit 10.
+    expect(JSON.parse(calls[1]!.body!).planes).toEqual([
+      "curated",
+      "concept",
+      "episodic",
+      "artifact",
+    ]);
+    expect(JSON.parse(calls[1]!.body!).limit).toBe(10);
+  });
+
+  it("test_recall_returns_shaped_content_for_agent_consumption", async () => {
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        body: {
+          results: [
+            {
+              object_id: "k-1",
+              score: 0.88,
+              plane: "curated",
+              content: "Eric prefers TypeScript.",
+              namespace: "eric/_shared/curated",
+            },
+          ],
+        },
+      },
+    ]);
+    const tool = createRecallTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("call", { query: "preference" });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]?.type).toBe("text");
+    const text = result.content[0]!.text;
+    expect(text).toContain("[curated]");
+    expect(text).toContain("0.88");
+    expect(text).toContain("Eric prefers TypeScript.");
+  });
+
+  it("test_recall_maps_core_unreachable_to_agent_visible_error", async () => {
+    const { fetch } = createMockFetch([{ throw: new TypeError("fetch failed") }]);
+    const tool = createRecallTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("call", { query: "x" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("Musubi recall failed");
+  });
+
+  it("uses agent presence when agentId is provided", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: { results: [] } }]);
+    const tool = createRecallTool({
+      client: makeClient(fetch),
+      config: makeConfig({
+        presence: { defaultId: "eric/openclaw", perAgent: { aoi: "eric/aoi" } },
+      }),
+      agentId: "aoi",
+    });
+
+    await tool.definition.execute("c", { query: "x" });
+
+    expect(JSON.parse(calls[0]!.body!).namespace).toBe("eric/aoi");
+  });
+
+  it("returns friendly message on zero results", async () => {
+    const { fetch } = createMockFetch([{ status: 200, body: { results: [] } }]);
+    const tool = createRecallTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", { query: "nothing matches" });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]?.text).toContain("No Musubi results");
+  });
+});

--- a/tests/tools/remember.test.ts
+++ b/tests/tools/remember.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { MusubiClient } from "../../src/musubi/client.js";
+import { createRememberTool } from "../../src/tools/remember.js";
+import type { MusubiConfig } from "../../src/config.js";
+import type { FetchLike } from "../../src/musubi/types.js";
+
+function makeConfig(overrides: Partial<MusubiConfig> = {}): MusubiConfig {
+  return {
+    core: { baseUrl: "https://musubi.test", token: "t", ...(overrides.core ?? {}) },
+    presence: { defaultId: "eric/openclaw", ...(overrides.presence ?? {}) },
+  };
+}
+
+function createMockFetch(script: Array<{ status: number; body?: unknown }>) {
+  const calls: Array<{ url: string; headers: Record<string, string>; body: string | undefined }> =
+    [];
+  let cursor = 0;
+  const fetch: FetchLike = async (url, init) => {
+    const headers: Record<string, string> = {};
+    if (init.headers) {
+      for (const [k, v] of Object.entries(init.headers as Record<string, string>)) {
+        headers[k] = v;
+      }
+    }
+    calls.push({ url, headers, body: typeof init.body === "string" ? init.body : undefined });
+    const def = script[cursor] ?? script[script.length - 1];
+    cursor += 1;
+    if (def === undefined) throw new Error("script exhausted");
+    return new Response(def.body !== undefined ? JSON.stringify(def.body) : null, {
+      status: def.status,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return { fetch, calls };
+}
+
+function makeClient(fetch: FetchLike) {
+  return new MusubiClient({
+    baseUrl: "https://musubi.test",
+    token: "t",
+    fetch,
+    sleep: async () => undefined,
+    random: () => 0,
+    generateRequestId: () => "r",
+    // A distinct auto-generated key per POST so we can tell overrides apart.
+    generateIdempotencyKey: () => "auto-idem",
+    retry: { maxAttempts: 1 },
+  });
+}
+
+const FIXED_NOW = () => new Date("2026-04-20T05:00:00.000Z");
+
+describe("createRememberTool", () => {
+  it("test_remember_accepts_content_importance_topics", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: { object_id: "stored-1" } }]);
+    const tool = createRememberTool({
+      client: makeClient(fetch),
+      config: makeConfig(),
+      now: FIXED_NOW,
+    });
+
+    await tool.definition.execute("call-1", {
+      content: "Eric said ship Musubi v2 this quarter.",
+      importance: 9,
+      topics: ["musubi", "roadmap"],
+    });
+
+    const body = JSON.parse(calls[0]!.body!);
+    expect(body.content).toBe("Eric said ship Musubi v2 this quarter.");
+    expect(body.importance).toBe(9);
+    expect(body.topics).toEqual(["musubi", "roadmap"]);
+  });
+
+  it("test_remember_posts_to_episodic_with_presence_namespace", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: { object_id: "stored" } }]);
+    const tool = createRememberTool({
+      client: makeClient(fetch),
+      config: makeConfig({
+        presence: { defaultId: "eric/openclaw", perAgent: { aoi: "eric/aoi" } },
+      }),
+      agentId: "aoi",
+      now: FIXED_NOW,
+    });
+
+    await tool.definition.execute("call", { content: "x" });
+
+    expect(calls[0]?.url).toBe("https://musubi.test/v1/episodic");
+    const body = JSON.parse(calls[0]!.body!);
+    expect(body.namespace).toBe("eric/aoi/episodic");
+    expect(body.capture_source).toBe("openclaw-agent-remember");
+  });
+
+  it("test_remember_idempotent_on_client_supplied_id", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200 }, { status: 200 }, { status: 200 }]);
+    const tool = createRememberTool({
+      client: makeClient(fetch),
+      config: makeConfig(),
+      now: FIXED_NOW,
+    });
+
+    // Client-supplied idempotency key overrides the auto-derived one.
+    await tool.definition.execute("call-1", { content: "x", idempotencyKey: "user-stable-id" });
+    // No override → derived from tool-call id.
+    await tool.definition.execute("call-2", { content: "x" });
+    // Same client-supplied key again → same idempotency header.
+    await tool.definition.execute("call-3", { content: "x", idempotencyKey: "user-stable-id" });
+
+    expect(calls[0]?.headers["Idempotency-Key"]).toBe("user-stable-id");
+    expect(calls[1]?.headers["Idempotency-Key"]).toBe("openclaw-remember:call-2");
+    expect(calls[2]?.headers["Idempotency-Key"]).toBe("user-stable-id");
+  });
+
+  it("defaults importance to 7 (higher than passive capture's 5)", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200 }]);
+    const tool = createRememberTool({
+      client: makeClient(fetch),
+      config: makeConfig(),
+      now: FIXED_NOW,
+    });
+
+    await tool.definition.execute("c", { content: "note" });
+
+    expect(JSON.parse(calls[0]!.body!).importance).toBe(7);
+  });
+
+  it("surfaces errors as tool errors, not throws", async () => {
+    const { fetch } = createMockFetch([{ status: 500, body: { error: "boom" } }]);
+    const tool = createRememberTool({
+      client: makeClient(fetch),
+      config: makeConfig(),
+      now: FIXED_NOW,
+    });
+
+    const result = await tool.definition.execute("c", { content: "note" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("Musubi remember failed");
+  });
+});

--- a/tests/tools/think.test.ts
+++ b/tests/tools/think.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import { MusubiClient } from "../../src/musubi/client.js";
+import { createThinkTool } from "../../src/tools/think.js";
+import type { MusubiConfig } from "../../src/config.js";
+import type { FetchLike } from "../../src/musubi/types.js";
+
+function makeConfig(overrides: Partial<MusubiConfig> = {}): MusubiConfig {
+  return {
+    core: { baseUrl: "https://musubi.test", token: "t", ...(overrides.core ?? {}) },
+    presence: { defaultId: "eric/openclaw", ...(overrides.presence ?? {}) },
+  };
+}
+
+function createMockFetch(script: Array<{ status: number; body?: unknown }>) {
+  const calls: Array<{ url: string; body: string | undefined }> = [];
+  let cursor = 0;
+  const fetch: FetchLike = async (url, init) => {
+    calls.push({ url, body: typeof init.body === "string" ? init.body : undefined });
+    const def = script[cursor] ?? script[script.length - 1];
+    cursor += 1;
+    if (def === undefined) throw new Error("script exhausted");
+    return new Response(def.body !== undefined ? JSON.stringify(def.body) : null, {
+      status: def.status,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return { fetch, calls };
+}
+
+function makeClient(fetch: FetchLike) {
+  return new MusubiClient({
+    baseUrl: "https://musubi.test",
+    token: "t",
+    fetch,
+    sleep: async () => undefined,
+    random: () => 0,
+    generateRequestId: () => "r",
+    generateIdempotencyKey: () => "i",
+    retry: { maxAttempts: 1 },
+  });
+}
+
+describe("createThinkTool", () => {
+  it("test_think_registered_with_to_presence_and_content_parameters", () => {
+    const { fetch } = createMockFetch([{ status: 200, body: {} }]);
+    const tool = createThinkTool({ client: makeClient(fetch), config: makeConfig() });
+    expect(tool.definition.name).toBe("musubi_think");
+    // TypeBox schema includes both required fields.
+    const schema = tool.definition.parameters;
+    // Properties access — TypeBox schemas serialize to JSON Schema.
+    const serialized = JSON.parse(JSON.stringify(schema));
+    expect(Object.keys(serialized.properties)).toContain("toPresence");
+    expect(Object.keys(serialized.properties)).toContain("content");
+  });
+
+  it("test_think_posts_to_thoughts_send_endpoint", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: { object_id: "ksuid-sent" } }]);
+    const tool = createThinkTool({ client: makeClient(fetch), config: makeConfig() });
+
+    await tool.definition.execute("call", {
+      toPresence: "eric/claude-code",
+      content: "deploy is done",
+    });
+
+    expect(calls[0]?.url).toBe("https://musubi.test/v1/thoughts/send");
+  });
+
+  it("test_think_carries_sending_agents_presence_as_from", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: {} }]);
+    const tool = createThinkTool({
+      client: makeClient(fetch),
+      config: makeConfig({
+        presence: { defaultId: "eric/openclaw", perAgent: { aoi: "eric/aoi" } },
+      }),
+      agentId: "aoi",
+    });
+
+    await tool.definition.execute("call", {
+      toPresence: "eric/rin",
+      content: "pick up the deploy please",
+    });
+
+    const body = JSON.parse(calls[0]!.body!);
+    expect(body.from_presence).toBe("eric/aoi");
+    expect(body.to_presence).toBe("eric/rin");
+    expect(body.namespace).toBe("eric/aoi");
+    expect(body.content).toBe("pick up the deploy please");
+  });
+
+  it("test_think_honors_configured_channel_and_importance", async () => {
+    const { fetch, calls } = createMockFetch([
+      { status: 200, body: {} },
+      { status: 200, body: {} },
+    ]);
+    const tool = createThinkTool({ client: makeClient(fetch), config: makeConfig() });
+
+    await tool.definition.execute("c1", {
+      toPresence: "eric/rin",
+      content: "x",
+      channel: "urgent",
+      importance: 9,
+    });
+    await tool.definition.execute("c2", { toPresence: "eric/rin", content: "x" });
+
+    const withOpts = JSON.parse(calls[0]!.body!);
+    expect(withOpts.channel).toBe("urgent");
+    expect(withOpts.importance).toBe(9);
+
+    const defaults = JSON.parse(calls[1]!.body!);
+    expect(defaults.channel).toBe("default");
+    expect(defaults.importance).toBe(5);
+  });
+
+  it("returns typed error on failure", async () => {
+    const { fetch } = createMockFetch([{ status: 503, body: { error: "down" } }]);
+    const tool = createThinkTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", {
+      toPresence: "eric/rin",
+      content: "x",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("Musubi think failed");
+  });
+});
+
+describe("test_all_tools_honor_approval_hooks_when_required", () => {
+  // Approval hooks (`before_tool_call` with `{ requireApproval: true }`) are
+  // enforced by OpenClaw *before* a tool's execute() runs. The tool itself
+  // has no special responsibility — it must simply run cleanly when invoked
+  // (approvals happen invisibly from the tool's perspective) and must NOT
+  // try to bypass the hook system.
+  //
+  // This asserts structurally: each tool's execute() is a normal function
+  // that returns a ToolResult. There is no side channel that could bypass
+  // an approval. OpenClaw gating before execute() is the system's job, not
+  // the tool's.
+  it("all three tools expose execute() as plain ToolResult-returning functions", async () => {
+    // Shared mock — each tool is called in isolation.
+    const responses = [
+      { status: 200, body: { results: [] } }, // recall
+      { status: 200, body: { object_id: "x" } }, // remember
+      { status: 200, body: { object_id: "y" } }, // think
+    ];
+    const { fetch } = createMockFetch(responses);
+    const { createRecallTool } = await import("../../src/tools/recall.js");
+    const { createRememberTool } = await import("../../src/tools/remember.js");
+    const client = makeClient(fetch);
+    const config = makeConfig();
+
+    const recall = createRecallTool({ client, config });
+    const remember = createRememberTool({ client, config });
+    const think = createThinkTool({ client, config });
+
+    const r1 = await recall.definition.execute("c1", { query: "x" });
+    const r2 = await remember.definition.execute("c2", { content: "x" });
+    const r3 = await think.definition.execute("c3", {
+      toPresence: "eric/rin",
+      content: "x",
+    });
+
+    for (const result of [r1, r2, r3]) {
+      expect(Array.isArray(result.content)).toBe(true);
+      expect(result.content[0]?.type).toBe("text");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Three agent-callable tools completing the OpenClaw-facing surface. Each factory returns \`{ definition, recommendedOptional: true }\` for the wiring slice to register via \`api.registerTool(def, { optional: true })\`.

## Slice

Closes #8. Built on #2, #3, #7.

## Tools

- **\`musubi_recall\`** — deep-path retrieve across all planes. Escape hatch when the passive supplement missed. \`POST /v1/retrieve\` with \`mode: "deep"\`, configurable plane filter + limit.
- **\`musubi_remember\`** — explicit episodic capture at importance 7 (above passive capture's 5). Optional client-supplied idempotency key.
- **\`musubi_think\`** — presence-to-presence send via \`POST /v1/thoughts/send\`. Recipient sees it in real-time via the SSE stream from #7.

## Approval hooks

OpenClaw enforces \`before_tool_call\` hooks with \`{ requireApproval: true }\` **before** the tool's execute() runs. Tools have no special responsibility — they just run cleanly when dispatched. The wiring slice decides which (if any) tools require approval per deployment policy.

\`test_all_tools_honor_approval_hooks_when_required\` asserts structurally: every tool's execute() is a plain \`ToolResult\`-returning function with no side channel that could bypass the hook system.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm format:check\` clean
- [x] \`pnpm test\` — **104/104**
- [x] \`pnpm build\` clean
- [x] All 13 named contract tests present and green

## Docs

- [x] \`CHANGELOG.md\` updated
- [ ] No contract change beyond ADR-0001

## Next up

Only [#15 wiring](https://github.com/ericmey/openclaw-musubi/issues/15) remains. Wiring ties everything together via \`definePluginEntry\` and schedules the prompt-supplement refresh loop.