### PR TITLE
release: v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to a calendar-flavored semantic versioning scheme
 
 ## [Unreleased]
 
+## [0.1.0] — 2026-04-22
+
+First tagged release. The plugin is loadable against OpenClaw via `definePluginEntry` and ships the full Musubi integration surface:
+
+- **Episodic capture mirror** — `agent_end` events become `POST /v1/episodic` captures. Failures never block OpenClaw's native memory write.
+- **Memory prompt supplement** — synchronous, cached `MemoryPromptSectionBuilder` with per-plane provenance labels. Background `refresh()` on a 60s interval.
+- **Memory corpus supplement** — agent-queryable `search`/`get` against Musubi's canonical retrieve surface.
+- **Thought-stream SSE consumer** — listens to `GET /v1/thoughts/stream` with all six consumer-expectation rules (jitter-backoff, persisted `Last-Event-ID`, bounded dedup, 403 no-reconnect, 60s ping-gap timeout, lex string object-id comparison).
+- **Three agent tools** — `musubi_recall` (deep-path retrieve), `musubi_remember` (explicit capture at importance 7), `musubi_think` (presence-to-presence thought send).
+- **Presence resolution** — maps OpenClaw agent ids to Musubi presences with per-agent token support.
+- **Typed HTTP client** — retry, idempotency, error taxonomy, per-request timeout.
+
+No runtime integration tests yet — the plugin is "built, not turned on." Load testing + a production cutover live behind the v0.x.y boundary; until then, v0.1.0 is an alpha suitable for sideload + exercise.
+
 ### Added
 
 - `src/plugin/bootstrap.ts` — wires every subsystem (slices #2–#8) into a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-musubi",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Musubi memory plane for OpenClaw agents — episodic capture, curated knowledge, and presence-to-presence thoughts with authority-weighted prompt supplements.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
No tracking Issue: release cut.

## Summary

First tagged release of \`openclaw-musubi\`. All eight build slices (#2–#15) have shipped; plugin is loadable against OpenClaw via \`definePluginEntry\` and ships the full Musubi integration surface (capture mirror, memory supplements, agent tools, SSE thought stream).

Version bump: \`0.0.1\` → \`0.1.0\`.

## What this release contains

- Episodic capture mirror via \`agent_end\`
- \`MemoryPromptSectionBuilder\` with background \`refresh()\`
- \`MemoryCorpusSupplement\` search/get
- Three agent tools: \`musubi_recall\`, \`musubi_remember\`, \`musubi_think\`
- SSE thought-stream consumer (all six consumer-expectation rules)
- Presence resolution with per-agent tokens
- Typed HTTP client with retry, idempotency, error taxonomy

## Not in this release

Production integration is "built, not turned on." Load testing + data migration + live cutover happen against a post-load-test-approval Musubi, tracked separately. This release is an alpha suitable for sideload + exercise in a dev environment.

## Test plan

- [x] \`pnpm typecheck\` ✓
- [x] \`pnpm lint\` ✓
- [x] \`pnpm test\` → 123/123 ✓
- [x] \`pnpm build\` ✓
- [x] \`pnpm format:check\` ✓
- [ ] CI on this PR
- [ ] Tag \`v0.1.0\` on \`main\` after merge
- [ ] GitHub release with CHANGELOG body