### PR TITLE
feat(v1.0): align with Musubi v1.0 endpoint rename + title promotion

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -90,8 +90,8 @@ The server requires `?namespace=...` on every GET-by-id endpoint:
 
 | Plane | Plugin calls | Server expects |
 |-------|-------------|----------------|
-| `curated` | `GET /v1/curated/{id}` | `GET /v1/curated-knowledge/{id}?namespace=...` |
-| `episodic` | `GET /v1/episodic/{id}` | `GET /v1/memories/{id}?namespace=...` |
+| `curated` | `GET /v1/curated/{id}` | `GET /v1/curated/{id}?namespace=...` |
+| `episodic` | `GET /v1/episodic/{id}` | `GET /v1/episodic/{id}?namespace=...` |
 | `concept` | `GET /v1/concepts/{id}` | `GET /v1/concepts/{id}?namespace=...` |
 | `artifact` | `GET /v1/artifacts/{id}` | `GET /v1/artifacts/{id}?namespace=...` |
 
@@ -145,8 +145,8 @@ Document the changed failure semantics if the strict-403 behavior is unacceptabl
 
 | Document claim | Server reality |
 |----------------|----------------|
-| `POST /v1/episodic` | Does not exist. Correct: `POST /v1/memories` |
-| `POST /v1/episodic/batch` | Does not exist. Correct: `POST /v1/memories/batch` |
+| `POST /v1/episodic` | ✅ Aligned in v1.0 (was `POST /v1/memories`) |
+| `POST /v1/episodic/batch` | ✅ Aligned in v1.0 (was `POST /v1/memories/batch`) |
 | Thought send idempotency via `client_id` in body | `ThoughtSendRequest` has **no** `client_id` field. Idempotency is header-only (`Idempotency-Key`). |
 | `POST /v1/thoughts/read` mentioned as polling fallback | Exists, but plugin doesn't implement it. |
 
@@ -216,8 +216,8 @@ The test header says:
 MUSUBI_LIVE_BASE_URL=http://musubi.mey.house:8100/v1
 ```
 
-`MusubiClient` appends `/v1/memories` to `baseUrl`. Following the docs literally
-produces `.../v1/v1/memories`. The `README.md` example correctly omits `/v1`, but
+`MusubiClient` appends `/v1/episodic` to `baseUrl`. Following the docs literally
+produces `.../v1/v1/episodic`. The `README.md` example correctly omits `/v1`, but
 the live test comment contradicts it.
 
 **Fix:** Remove `/v1` from the live test docstring.
@@ -267,7 +267,7 @@ config UI help text.
 ### 38. Server returns `202 Accepted` for captures, but plugin tests/docs expect `200 OK`
 **File:** `src/musubi/api/routers/writes_episodic.py` (implied by OpenAPI)
 
-The OpenAPI shows `202` for `POST /v1/memories`, `POST /v1/memories/batch`, and
+The OpenAPI shows `202` for `POST /v1/episodic`, `POST /v1/episodic/batch`, and
 `POST /v1/thoughts/send`. Plugin tests mock `status: 200`. `response.ok` covers
 200–299, but the test suite validates against the wrong status code.
 

--- a/src/capture/mirror.ts
+++ b/src/capture/mirror.ts
@@ -64,7 +64,7 @@ export function createCaptureMirror(options: CreateCaptureMirrorOptions): Captur
       const { presence, payload } = resolved;
 
       try {
-        await client.post("/v1/memories", {
+        await client.post("/v1/episodic", {
           body: toCanonicalCapture(payload),
           idempotencyKey: deriveIdempotencyKey(event),
           token: presence.token,
@@ -80,7 +80,7 @@ export function createCaptureMirror(options: CreateCaptureMirrorOptions): Captur
     async handleBatch(events: readonly CaptureEvent[]): Promise<void> {
       if (!enabled || events.length === 0) return;
 
-      // One namespace per batch — the canonical `/v1/memories/batch`
+      // One namespace per batch — the canonical `/v1/episodic/batch`
       // endpoint takes a single top-level `namespace` and a list of
       // `items` rather than repeating the namespace per row. Group
       // events by their resolved (namespace, token) pair before dispatching
@@ -115,7 +115,7 @@ export function createCaptureMirror(options: CreateCaptureMirrorOptions): Captur
           tags: c.tags,
         }));
         try {
-          await client.post("/v1/memories/batch", {
+          await client.post("/v1/episodic/batch", {
             body: { namespace: bucket.namespace, items },
             idempotencyKey: `batch:${bucket.keys.join(",")}`,
             token: bucket.token,

--- a/src/capture/translate.ts
+++ b/src/capture/translate.ts
@@ -54,8 +54,8 @@ export type EpisodicCapturePayload = {
 };
 
 /**
- * Body shape accepted by `POST /v1/memories` on the canonical Musubi
- * API as of v0.4.0. Kept deliberately narrow — any field the
+ * Body shape accepted by `POST /v1/episodic` on the canonical Musubi
+ * API as of v1.0. Kept deliberately narrow — any field the
  * canonical `CaptureRequest` does not declare is silently dropped
  * server-side, which is why we prefer to fold our audit metadata
  * into `tags` rather than sending rich keys that never reach the

--- a/src/supplement/corpus.ts
+++ b/src/supplement/corpus.ts
@@ -65,6 +65,7 @@ type MusubiRetrieveRow = {
   readonly plane: string;
   readonly content: string;
   readonly namespace: string;
+  readonly title?: string | null;
   readonly extra?: Record<string, unknown>;
 };
 
@@ -215,6 +216,7 @@ function toCorpusSearchResult(row: MusubiRetrieveRow): CorpusSearchResult {
     path: `${row.plane}/${row.object_id}`,
     score: row.score,
     snippet: row.content.slice(0, SNIPPET_MAX_CHARS),
+    title: row.title ?? undefined,
     id: row.object_id,
     source: row.namespace,
     provenanceLabel: provenanceLabelFor(row.plane),

--- a/src/supplement/prompt.ts
+++ b/src/supplement/prompt.ts
@@ -39,6 +39,7 @@ type StandingContextItem = {
   readonly plane: string;
   readonly content: string;
   readonly source: string;
+  readonly title?: string;
 };
 
 type MusubiRetrieveRow = {
@@ -47,6 +48,7 @@ type MusubiRetrieveRow = {
   readonly plane: string;
   readonly content: string;
   readonly namespace: string;
+  readonly title?: string | null;
 };
 
 type MusubiRetrieveResponse = {
@@ -92,7 +94,8 @@ export function createPromptSupplement(options: CreatePromptSupplementOptions): 
         const header = SECTION_HEADERS[plane] ?? `**Musubi ${plane}:**`;
         lines.push(header);
         for (const item of items) {
-          lines.push(`- ${item.content} (${item.source})`);
+          const label = item.title ? `${item.title} (${item.source})` : item.source;
+          lines.push(`- ${item.content} (${label})`);
         }
       }
 
@@ -147,6 +150,7 @@ export function createPromptSupplement(options: CreatePromptSupplementOptions): 
           plane: row.plane,
           content: row.content,
           source: row.namespace,
+          title: row.title ?? undefined,
         }),
       );
     },

--- a/src/supplement/prompt.ts
+++ b/src/supplement/prompt.ts
@@ -94,7 +94,7 @@ export function createPromptSupplement(options: CreatePromptSupplementOptions): 
         const header = SECTION_HEADERS[plane] ?? `**Musubi ${plane}:**`;
         lines.push(header);
         for (const item of items) {
-          const label = item.title ? `${item.title} (${item.source})` : item.source;
+          const label = item.title ? `${item.title} — ${item.source}` : item.source;
           lines.push(`- ${item.content} (${label})`);
         }
       }

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -48,6 +48,7 @@ type MusubiRetrieveRow = {
   readonly plane: string;
   readonly content: string;
   readonly namespace: string;
+  readonly title?: string | null;
 };
 
 type MusubiRetrieveResponse = {
@@ -128,7 +129,8 @@ function formatResults(rows: readonly MusubiRetrieveRow[]): string {
   lines.push(`Musubi returned ${rows.length} result(s):`);
   lines.push("");
   for (const row of rows) {
-    lines.push(`[${row.plane}] (score ${row.score.toFixed(2)}) ${row.namespace}/${row.object_id}`);
+    const label = row.title ? `${row.title}` : `${row.namespace}/${row.object_id}`;
+    lines.push(`[${row.plane}] (score ${row.score.toFixed(2)}) ${label}`);
     lines.push(row.content);
     lines.push("");
   }

--- a/src/tools/remember.ts
+++ b/src/tools/remember.ts
@@ -68,7 +68,7 @@ export function createRememberTool(options: CreateRememberToolOptions): Remember
 
         try {
           const response = await client.post<{ object_id?: string }>("/v1/episodic", {
-            // Canonical `CaptureRequest` (Musubi v0.4.0) accepts
+            // Canonical `CaptureRequest` (Musubi v1.0) accepts
             // {namespace, content, summary?, tags, importance, created_at?}.
             // Audit metadata folds into `tags` with prefixes so it
             // round-trips without requiring a canonical API extension;

--- a/src/tools/remember.ts
+++ b/src/tools/remember.ts
@@ -67,7 +67,7 @@ export function createRememberTool(options: CreateRememberToolOptions): Remember
         const idempotencyKey = params.idempotencyKey ?? `openclaw-remember:${toolCallId}`;
 
         try {
-          const response = await client.post<{ object_id?: string }>("/v1/memories", {
+          const response = await client.post<{ object_id?: string }>("/v1/episodic", {
             // Canonical `CaptureRequest` (Musubi v0.4.0) accepts
             // {namespace, content, summary?, tags, importance, created_at?}.
             // Audit metadata folds into `tags` with prefixes so it

--- a/tests/capture/mirror.test.ts
+++ b/tests/capture/mirror.test.ts
@@ -106,7 +106,7 @@ describe("createCaptureMirror", () => {
     await mirror.handleEvent({ id: "evt-1", content: "hello" });
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.url).toBe("https://musubi.test/v1/memories");
+    expect(calls[0]?.url).toBe("https://musubi.test/v1/episodic");
     expect(calls[0]?.method).toBe("POST");
     expect(calls[0]?.headers["Idempotency-Key"]).toBe("openclaw-mirror:evt-1");
     const body = JSON.parse(calls[0]!.body!);
@@ -133,7 +133,7 @@ describe("createCaptureMirror", () => {
     ]);
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.url).toBe("https://musubi.test/v1/memories/batch");
+    expect(calls[0]?.url).toBe("https://musubi.test/v1/episodic/batch");
     const body = JSON.parse(calls[0]!.body!);
     // Canonical batch shape: {namespace, items[]}. Each item carries
     // content/importance/tags — no per-item namespace or idempotency

--- a/tests/live/smoke.live.test.ts
+++ b/tests/live/smoke.live.test.ts
@@ -75,7 +75,7 @@ describeLive("openclaw-musubi × live Musubi (smoke)", () => {
       topics: ["smoke", "mirror"],
     });
 
-    const verify = await client.post<{ object_id?: string; state?: string }>("/v1/memories", {
+    const verify = await client.post<{ object_id?: string; state?: string }>("/v1/episodic", {
       body: {
         namespace: `${NS_ROOT}/episodic`,
         content: `mirror smoke probe ${eventId} (verify)`,
@@ -87,7 +87,7 @@ describeLive("openclaw-musubi × live Musubi (smoke)", () => {
     expect(verify.state).toBe("provisional");
   });
 
-  it("musubi_remember tool POSTs the canonical /v1/memories shape", async () => {
+  it("musubi_remember tool POSTs the canonical /v1/episodic shape", async () => {
     const client = makeLiveClient();
     const config = makeLiveConfig();
     const tool = createRememberTool({ client, config });
@@ -155,7 +155,7 @@ describeLive("openclaw-musubi × live Musubi (smoke)", () => {
     // The client maps 403 → ForbiddenError; the mirror/tool code treats
     // it as a non-blocking failure and the outer catch returns cleanly.
     await expect(
-      client.post("/v1/memories", {
+      client.post("/v1/episodic", {
         body: {
           namespace: "eric/claude-code/episodic",
           content: "should be forbidden",

--- a/tests/tools/remember.test.ts
+++ b/tests/tools/remember.test.ts
@@ -69,7 +69,7 @@ describe("createRememberTool", () => {
     expect(body.content).toBe("Eric said ship Musubi v2 this quarter.");
     expect(body.importance).toBe(9);
     // `topics` is folded into `tags` at the canonical boundary so the
-    // request matches `POST /v1/memories`'s CaptureRequest shape.
+    // request matches `POST /v1/episodic`'s CaptureRequest shape.
     expect(body.tags).toEqual(
       expect.arrayContaining(["musubi", "roadmap", "src:openclaw-agent-remember", "ref:call-1"]),
     );
@@ -88,7 +88,7 @@ describe("createRememberTool", () => {
 
     await tool.definition.execute("call", { content: "x" });
 
-    expect(calls[0]?.url).toBe("https://musubi.test/v1/memories");
+    expect(calls[0]?.url).toBe("https://musubi.test/v1/episodic");
     const body = JSON.parse(calls[0]!.body!);
     expect(body.namespace).toBe("eric/aoi/episodic");
     // Canonical CaptureRequest has no `capture_source` — it lives in


### PR DESCRIPTION
## Summary

Updates the plugin to match the Musubi v1.0 breaking changes that have landed upstream.

## Changes

- **Endpoint rename** — `POST /v1/memories` → `POST /v1/episodic` and `/v1/memories/batch` → `/v1/episodic/batch` across capture mirror, remember tool, tests, docs, and comments.
- **Top-level title on RetrieveResultRow** — `MusubiRetrieveRow` now carries `title?: string | null` at the top level. All three consumers updated:
  - `CorpusSupplement.search()` surfaces it in `CorpusSearchResult.title`
  - `RecallTool` includes it in formatted output
  - `PromptSupplement` carries it through cache and renders it in prompt lines
- **No plugin change needed for Last-Event-ID replay** — we already send the header; server-side support is coming in #233.

## Blockers

- [ ] Musubi #233 — Last-Event-ID replay on `/v1/thoughts/stream` (server-side; plugin is ready)
- [ ] Musubi #235 — dead auth scope cleanup (server-side; no plugin impact)

## Validation

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm test` — 128 passed, 5 skipped (live), 0 failed
