### PR TITLE
feat(thoughts): history backfill on X-Musubi-Replay-Truncated

### DIFF
--- a/src/plugin/bootstrap.ts
+++ b/src/plugin/bootstrap.ts
@@ -93,6 +93,7 @@ export type BootstrapOptions = {
   readonly thoughtStreamFactory?: (args: {
     config: MusubiConfig;
     fetch?: FetchLike;
+    client?: MusubiClient;
   }) => ThoughtStream;
   /** Prompt-supplement refresh interval. Default 60s. */
   readonly refreshIntervalMs?: number;
@@ -138,10 +139,6 @@ export async function bootstrap(options: BootstrapOptions): Promise<LifecycleHan
     },
     now: options.now,
   });
-  const recallTool = createRecallTool({ client, config });
-  const rememberTool = createRememberTool({ client, config });
-  const thinkTool = createThinkTool({ client, config });
-
   // 4. Register capabilities. Order matters only loosely (supplements
   //    before tools, hooks last) but we keep it stable for test #11.
   api.registerMemoryCorpusSupplement(corpusSupplement);
@@ -154,15 +151,28 @@ export async function bootstrap(options: BootstrapOptions): Promise<LifecycleHan
       citationsMode: params.citationsMode,
     });
   api.registerMemoryPromptSupplement(promptBuilder);
-  api.registerTool(recallTool.definition);
-  api.registerTool(rememberTool.definition);
-  api.registerTool(thinkTool.definition);
+  // Register tools as factories so each execution receives the active
+  // agent's identity from OpenClaw's runtime context. Static tool
+  // registration captures the default presence once at load time,
+  // which breaks per-agent token isolation.
+  api.registerTool(
+    (ctx: { agentId?: string }) =>
+      createRecallTool({ client, config, agentId: ctx.agentId }).definition,
+  );
+  api.registerTool(
+    (ctx: { agentId?: string }) =>
+      createRememberTool({ client, config, agentId: ctx.agentId }).definition,
+  );
+  api.registerTool(
+    (ctx: { agentId?: string }) =>
+      createThinkTool({ client, config, agentId: ctx.agentId }).definition,
+  );
 
   // `agent_end` → `capture-mirror.handleEvent`. Failures are swallowed
   // inside the mirror so a Musubi outage never blocks OpenClaw's own
   // memory write (ADR-0001).
-  api.on("agent_end", ((event: unknown, _ctx: unknown) => {
-    const captureEvent = translateAgentEndEvent(event);
+  api.on("agent_end", ((event: unknown, ctx: { agentId?: string }) => {
+    const captureEvent = translateAgentEndEvent(event, ctx.agentId);
     if (captureEvent === undefined) return;
     void captureMirror.handleEvent(captureEvent);
   }) as unknown as (...args: unknown[]) => unknown);
@@ -202,8 +212,9 @@ export async function bootstrap(options: BootstrapOptions): Promise<LifecycleHan
           config: args.config,
           fetch: args.fetch,
           maxBackoffMs: config.thoughts?.reconnect?.maxBackoffMs,
+          client: args.client,
         }));
-    const stream = streamFactory({ config, fetch: options.fetch });
+    const stream = streamFactory({ config, fetch: options.fetch, client });
     // start() enters the reconnect loop; we don't await it (it blocks
     // while running and resolves only on stop()).
     void stream.start({
@@ -233,7 +244,10 @@ export async function bootstrap(options: BootstrapOptions): Promise<LifecycleHan
  * test; a richer extraction is owned by a future slice if + when
  * OpenClaw exposes a canonical "capture-eligible" extraction helper.
  */
-function translateAgentEndEvent(event: unknown):
+function translateAgentEndEvent(
+  event: unknown,
+  agentIdFromContext?: string,
+):
   | {
       id: string;
       content: string;
@@ -246,7 +260,6 @@ function translateAgentEndEvent(event: unknown):
     messages?: unknown[];
     runId?: unknown;
     sessionId?: unknown;
-    agentId?: unknown;
   };
   if (!Array.isArray(e.messages) || e.messages.length === 0) return undefined;
 
@@ -258,8 +271,7 @@ function translateAgentEndEvent(event: unknown):
     (typeof e.runId === "string" && e.runId) ||
     (typeof e.sessionId === "string" && e.sessionId) ||
     `agent_end-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-  const agentId = typeof e.agentId === "string" ? e.agentId : undefined;
-  return { id, content, agentId };
+  return { id, content, agentId: agentIdFromContext };
 }
 
 function extractMessageText(msg: unknown): string | undefined {

--- a/src/supplement/corpus.ts
+++ b/src/supplement/corpus.ts
@@ -8,6 +8,23 @@ import { resolvePresence } from "../presence/resolver.js";
 import { buildRetrieveTargets } from "./retrieve-targets.js";
 
 /**
+ * Extract a bare agent id from an OpenClaw session key.
+ *
+ * OpenClaw session keys are composite strings like `agent:nyla:main`
+ * or `agent:ops:telegram:direct:owner:tail`. The second colon-delimited
+ * segment is the agent id. If the input is already a bare id (no
+ * `agent:` prefix) it is returned unchanged.
+ */
+function resolveAgentIdFromSessionKey(sessionKey: string | undefined): string | undefined {
+  if (!sessionKey) return undefined;
+  const parts = sessionKey.split(":").filter(Boolean);
+  if (parts.length >= 3 && parts[0] === "agent") {
+    return parts[1];
+  }
+  return sessionKey;
+}
+
+/**
  * Structural shape of a single result row consumed by OpenClaw's
  * `MemoryCorpusSupplement.search` callback. Mirrors `MemoryCorpusSearchResult`
  * in the OpenClaw SDK (`src/plugins/memory-state.ts`) — duplicated here so
@@ -111,7 +128,9 @@ export function createCorpusSupplement(options: CreateCorpusSupplementOptions): 
 
       let presence;
       try {
-        presence = resolvePresence(config, { agentId: params.agentSessionKey });
+        presence = resolvePresence(config, {
+          agentId: resolveAgentIdFromSessionKey(params.agentSessionKey),
+        });
       } catch {
         return [];
       }
@@ -162,7 +181,9 @@ export function createCorpusSupplement(options: CreateCorpusSupplementOptions): 
 
       let presence;
       try {
-        presence = resolvePresence(config, { agentId: params.agentSessionKey });
+        presence = resolvePresence(config, {
+          agentId: resolveAgentIdFromSessionKey(params.agentSessionKey),
+        });
       } catch {
         return null;
       }

--- a/src/thoughts/stream.ts
+++ b/src/thoughts/stream.ts
@@ -1,4 +1,5 @@
 import type { MusubiConfig } from "../config.js";
+import type { MusubiClient } from "../musubi/client.js";
 import { resolvePresence } from "../presence/resolver.js";
 import { nextSseBackoffMs } from "./backoff.js";
 import { BoundedDedupSet } from "./dedup.js";
@@ -54,6 +55,8 @@ export type CreateThoughtStreamOptions = {
   readonly include?: string;
   /** Upper bound on reconnect backoff. Defaults to 60s. */
   readonly maxBackoffMs?: number;
+  /** Musubi client for history backfill when replay is truncated. */
+  readonly client?: MusubiClient;
 };
 
 export type ThoughtStream = {
@@ -111,6 +114,8 @@ export function createThoughtStream(options: CreateThoughtStreamOptions): Though
 
       const url = buildStreamUrl(baseUrl, presence.presence, options.include);
 
+      const client = options.client;
+
       while (running) {
         const connectedAtCandidate = now();
         const outcome = await runOneConnection({
@@ -138,6 +143,26 @@ export function createThoughtStream(options: CreateThoughtStreamOptions): Though
         if (!running) {
           handlers.onDisconnect?.("stopped");
           return;
+        }
+
+        // History backfill when the server signals replay truncation.
+        // We backfill *before* reconnecting so the next Last-Event-ID
+        // covers the gap.
+        if (outcome.connected && outcome.truncated && client !== undefined) {
+          try {
+            await backfillHistory({
+              client,
+              namespace: presence.namespaces.thought,
+              presence: presence.presence,
+              token: presence.token,
+              dedup,
+              handlers,
+              persistence,
+              getRunning: () => running,
+            });
+          } catch {
+            // Backfill is best-effort; ignore errors and reconnect normally.
+          }
         }
 
         handlers.onDisconnect?.(outcome.kind);
@@ -175,10 +200,10 @@ type ConnectionOutcome =
   | { kind: "auth-fail"; status: 401 | 403; connected: false }
   | { kind: "http-error"; status: number; connected: false; retryAfterMs?: number }
   | { kind: "network-error"; connected: false }
-  | { kind: "stream-error"; connected: true }
-  | { kind: "ping-gap-timeout"; connected: true }
-  | { kind: "ended"; connected: true }
-  | { kind: "close"; connected: true; reconnectAfterMs: number | undefined };
+  | { kind: "stream-error"; connected: true; truncated?: boolean }
+  | { kind: "ping-gap-timeout"; connected: true; truncated?: boolean }
+  | { kind: "ended"; connected: true; truncated?: boolean }
+  | { kind: "close"; connected: true; reconnectAfterMs: number | undefined; truncated?: boolean };
 
 type ConnectionContext = {
   url: string;
@@ -242,6 +267,8 @@ async function runOneConnection(ctx: ConnectionContext): Promise<ConnectionOutco
     return { kind: "http-error", status: response.status, connected: false, retryAfterMs };
   }
 
+  const truncated = response.headers.get("X-Musubi-Replay-Truncated") === "true";
+
   resetPingTimer();
   ctx.handlers.onConnected?.();
 
@@ -249,7 +276,7 @@ async function runOneConnection(ctx: ConnectionContext): Promise<ConnectionOutco
     for await (const frame of parseSseStream(response.body)) {
       resetPingTimer();
       if (!ctx.getRunning()) {
-        return { kind: "ended", connected: true };
+        return { kind: "ended", connected: true, truncated };
       }
 
       if (frame.event === "thought") {
@@ -266,16 +293,17 @@ async function runOneConnection(ctx: ConnectionContext): Promise<ConnectionOutco
           kind: "close",
           connected: true,
           reconnectAfterMs: data?.reconnect_after_ms,
+          truncated,
         };
       }
       // Pings just reset the timer (already done above).
     }
-    return { kind: "ended", connected: true };
+    return { kind: "ended", connected: true, truncated };
   } catch {
     if (pingGapTriggered) {
-      return { kind: "ping-gap-timeout", connected: true };
+      return { kind: "ping-gap-timeout", connected: true, truncated };
     }
-    return { kind: "stream-error", connected: true };
+    return { kind: "stream-error", connected: true, truncated };
   } finally {
     if (pingTimer) clearTimeout(pingTimer);
   }
@@ -355,4 +383,75 @@ function parseRetryAfter(header: string | null, now: () => number = Date.now): n
     return Math.max(0, dateMs - now());
   }
   return undefined;
+}
+
+// ------------------------------------------------------------------
+// History backfill — triggered when X-Musubi-Replay-Truncated signals
+// the server couldn't fit all missed events into the 500-event replay cap.
+// ------------------------------------------------------------------
+
+type ThoughtHistoryItem = {
+  readonly object_id: string;
+  readonly content?: unknown;
+  readonly [key: string]: unknown;
+};
+
+type ThoughtHistoryResponse = {
+  readonly items: readonly ThoughtHistoryItem[];
+};
+
+type BackfillContext = {
+  readonly client: MusubiClient;
+  readonly namespace: string;
+  readonly presence: string;
+  readonly token: string;
+  readonly dedup: BoundedDedupSet;
+  readonly handlers: ThoughtStreamHandlers;
+  readonly persistence: LastEventIdStore;
+  readonly getRunning: () => boolean;
+};
+
+const BACKFILL_LIMIT = 1_000;
+
+async function backfillHistory(ctx: BackfillContext): Promise<void> {
+  const response = await ctx.client.post<ThoughtHistoryResponse>("/v1/thoughts/history", {
+    body: {
+      namespace: ctx.namespace,
+      presence: ctx.presence,
+      query_text: "*",
+      limit: BACKFILL_LIMIT,
+    },
+    token: ctx.token,
+  });
+
+  const items = response.items ?? [];
+  // Sort ascending by object_id so persistence advances monotonically.
+  const sorted = [...items].sort((a, b) => {
+    if (a.object_id < b.object_id) return -1;
+    if (a.object_id > b.object_id) return 1;
+    return 0;
+  });
+
+  // Read the current cursor so we never move it backwards.
+  const cursor = await ctx.persistence.read();
+
+  for (const item of sorted) {
+    if (!ctx.getRunning()) break;
+
+    const thought: ThoughtPayload = {
+      object_id: item.object_id,
+      content: typeof item.content === "string" ? item.content : "",
+      from_presence: typeof item.from_presence === "string" ? item.from_presence : "",
+      to_presence: typeof item.to_presence === "string" ? item.to_presence : "",
+      namespace: typeof item.namespace === "string" ? item.namespace : ctx.namespace,
+      sent_at: typeof item.sent_at === "string" ? item.sent_at : new Date().toISOString(),
+    };
+    if (ctx.dedup.add(thought.object_id)) {
+      await ctx.handlers.onThought(thought);
+      // Only advance the cursor forward (lex ascending); never backward.
+      if (cursor === undefined || thought.object_id > cursor) {
+        await ctx.persistence.write(thought.object_id);
+      }
+    }
+  }
 }

--- a/tests/plugin/bootstrap.test.ts
+++ b/tests/plugin/bootstrap.test.ts
@@ -184,7 +184,18 @@ describe("bootstrap: capability registration", () => {
     await bootstrap(commonOpts(api));
     const tools = api.events.filter((e) => e.kind === "registerTool");
     expect(tools).toHaveLength(3);
-    const names = tools.map((t) => (t.arg as { name: string }).name).sort();
+    const names = tools
+      .map((t) => {
+        const arg = t.arg as unknown;
+        // OpenClaw supports both static tools and factory functions.
+        // Factories receive { agentId?: string } at execution time.
+        const tool =
+          typeof arg === "function"
+            ? (arg as (ctx: { agentId?: string }) => { name: string })({ agentId: "test" })
+            : (arg as { name: string });
+        return tool.name;
+      })
+      .sort();
     expect(names).toEqual(["musubi_recall", "musubi_remember", "musubi_think"]);
   });
 });
@@ -267,7 +278,12 @@ describe("bootstrap: integration wiring", () => {
     const kinds = api.events.map((e) => {
       if (e.kind === "on") return `on:${e.hook}`;
       if (e.kind === "registerTool") {
-        const name = (e.arg as { name?: string }).name ?? "<unnamed>";
+        const arg = e.arg as unknown;
+        const tool =
+          typeof arg === "function"
+            ? (arg as (ctx: { agentId?: string }) => { name?: string })({ agentId: "test" })
+            : (arg as { name?: string });
+        const name = tool.name ?? "<unnamed>";
         return `registerTool:${name}`;
       }
       return e.kind;

--- a/tests/thoughts/stream.test.ts
+++ b/tests/thoughts/stream.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createThoughtStream, type ThoughtPayload } from "../../src/thoughts/stream.js";
 import type { FetchForStream } from "../../src/thoughts/stream.js";
 import { BoundedDedupSet } from "../../src/thoughts/dedup.js";
 import { InMemoryLastEventIdStore } from "../../src/thoughts/persistence.js";
 import type { MusubiConfig } from "../../src/config.js";
+import type { MusubiClient } from "../../src/musubi/client.js";
 
 function makeConfig(overrides: Partial<MusubiConfig> = {}): MusubiConfig {
   return {
@@ -589,5 +590,176 @@ describe("createThoughtStream", () => {
     await startPromise;
     expect(stream.isRunning()).toBe(false);
     expect(requests.length).toBe(1); // no reconnect after stop
+  });
+
+  it("detects X-Musubi-Replay-Truncated and backfills via history", async () => {
+    const historyCalls: unknown[] = [];
+    const mockClient = {
+      post: vi.fn(async <T>(_path: string, opts: { body: unknown; token?: string }): Promise<T> => {
+        historyCalls.push(opts.body);
+        return { items: [{ object_id: "hist-1", content: "backfilled" }] } as T;
+      }),
+    } as unknown as MusubiClient;
+
+    const received: ThoughtPayload[] = [];
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        actions: [
+          { type: "frames", text: makeThoughtFrame({ object_id: "k1", content: "live" }) },
+          { type: "frames", text: frame("close", undefined, { reason: "server-shutdown" }) },
+          { type: "close" },
+        ],
+        // The truncation header is set on the Response, which our mock
+        // fetch factory doesn't expose per-action. We simulate it by
+        // making the second connection (after backfill+reconnect) return
+        // a non-truncated close so the test terminates.
+      },
+      {
+        status: 200,
+        actions: [{ type: "close" }],
+      },
+    ]);
+
+    // Override the Response constructor to inject the truncation header
+    // on the first connection only.
+    let connectionCount = 0;
+    const fetchWithTruncation: FetchForStream = async (url, init) => {
+      connectionCount += 1;
+      const resp = await fetch(url, init);
+      if (connectionCount === 1) {
+        // Clone the response with the truncation header added.
+        const body = resp.body;
+        const headers = new Headers(resp.headers);
+        headers.set("X-Musubi-Replay-Truncated", "true");
+        return new Response(body, { status: resp.status, headers });
+      }
+      return resp;
+    };
+
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch: fetchWithTruncation,
+      client: mockClient,
+      sleep: async () => undefined,
+      random: () => 0,
+    });
+
+    await stream.start({
+      onThought: (t) => {
+        received.push(t);
+        if (received.length >= 2) void stream.stop();
+      },
+    });
+
+    // Should have received the live thought + the backfilled thought.
+    expect(received.length).toBeGreaterThanOrEqual(2);
+    expect(received.some((t) => t.content === "live")).toBe(true);
+    expect(received.some((t) => t.content === "backfilled")).toBe(true);
+    expect(historyCalls.length).toBe(1);
+  });
+
+  it("dedups backfilled thoughts already seen in replay", async () => {
+    const mockClient = {
+      post: vi.fn(async <T>(): Promise<T> => {
+        return {
+          items: [{ object_id: "k1", content: "duplicate" }],
+        } as T;
+      }),
+    } as unknown as MusubiClient;
+
+    const received: string[] = [];
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        actions: [
+          { type: "frames", text: makeThoughtFrame({ object_id: "k1", content: "first" }) },
+          { type: "close" },
+        ],
+      },
+      { status: 200, actions: [{ type: "close" }] },
+    ]);
+
+    let connectionCount = 0;
+    const fetchWithTruncation: FetchForStream = async (url, init) => {
+      connectionCount += 1;
+      const resp = await fetch(url, init);
+      if (connectionCount === 1) {
+        const body = resp.body;
+        const headers = new Headers(resp.headers);
+        headers.set("X-Musubi-Replay-Truncated", "true");
+        return new Response(body, { status: resp.status, headers });
+      }
+      return resp;
+    };
+
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch: fetchWithTruncation,
+      client: mockClient,
+      sleep: async () => undefined,
+      random: () => 0,
+    });
+
+    await stream.start({
+      onThought: (t) => {
+        received.push(t.object_id);
+      },
+      onDisconnect: () => {
+        // Stop after the first disconnect so the backfill path (which
+        // runs before disconnect) has a chance to complete.
+        if (received.length >= 1) void stream.stop();
+      },
+    });
+
+    // Verify the backfill endpoint was actually called.
+    expect(mockClient.post).toHaveBeenCalledTimes(1);
+
+    // k1 was seen in replay; the backfill duplicate must be deduped.
+    expect(received.filter((id) => id === "k1").length).toBe(1);
+  });
+
+  it("gracefully skips backfill when client is not provided", async () => {
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        actions: [
+          { type: "frames", text: makeThoughtFrame({ object_id: "k1" }) },
+          { type: "close" },
+        ],
+      },
+      { status: 200, actions: [{ type: "close" }] },
+    ]);
+
+    let connectionCount = 0;
+    const fetchWithTruncation: FetchForStream = async (url, init) => {
+      connectionCount += 1;
+      const resp = await fetch(url, init);
+      if (connectionCount === 1) {
+        const body = resp.body;
+        const headers = new Headers(resp.headers);
+        headers.set("X-Musubi-Replay-Truncated", "true");
+        return new Response(body, { status: resp.status, headers });
+      }
+      return resp;
+    };
+
+    const stream = createThoughtStream({
+      config: makeConfig(),
+      fetch: fetchWithTruncation,
+      // no client
+      sleep: async () => undefined,
+      random: () => 0,
+    });
+
+    let seen = 0;
+    await stream.start({
+      onThought: () => {
+        seen += 1;
+        if (seen >= 1) void stream.stop();
+      },
+    });
+
+    expect(seen).toBe(1); // no crash, normal replay processed
   });
 });


### PR DESCRIPTION
## Summary

Implements Option 3 from the v1.0 catch-up review: full history backfill when the server signals replay truncation. Also fixes three Codex-identified integration bugs in the host wiring layer.

## Changes

### History backfill (new feature)

- `CreateThoughtStreamOptions` gains optional `client: MusubiClient`
- `ConnectionOutcome` (connected variants) gains `truncated?: boolean`
- `runOneConnection` reads `X-Musubi-Replay-Truncated` response header
- Backfill loop: after any connected outcome with `truncated: true`, calls `POST /v1/thoughts/history` before reconnecting
- `backfillHistory()`: fetches up to 1,000 recent thoughts, sorts by `object_id` ascending, processes through normal `dedup -> onThought -> persistence.write` path
- Gracefully skips backfill when `client` is absent (test compatibility)
- Bootstrap wiring: passes `client` into `createThoughtStream`

### Codex integration fixes

1. **Static tool registration** — tools are now registered as `OpenClawPluginToolFactory` functions so each execution receives the active agent's `ctx.agentId` from OpenClaw's runtime context. Previously tools were constructed once at plugin load with `agentId: undefined`, causing every tool call to resolve the default presence.

2. **`agent_end` hook context** — the `agent_end` handler now reads `agentId` from the `PluginHookAgentContext` (second argument) and passes it to the capture mirror. Previously `_ctx` was discarded, so passive capture always resolved the default presence regardless of which agent ended.

3. **`agentSessionKey` parsing** — `MemoryCorpusSupplement.search()` and `.get()` now parse the composite OpenClaw session key format (`agent:<id>:<rest>`) to extract the bare `agentId` before resolving presence. Previously `agent:nyla:main` was passed directly as `agentId`, causing a miss and fallback to default.

## Tests

- `detects X-Musubi-Replay-Truncated and backfills via history`
- `dedups backfilled thoughts already seen in replay`
- `gracefully skips backfill when client is not provided`
- Bootstrap tests updated to handle factory-based tool registration

## Validation

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm test` — 131 passed, 5 skipped (live), 0 failed
