### PR TITLE
feat(supplement): tenant-wide retrieve via wildcard base

### DIFF
--- a/src/supplement/retrieve-targets.ts
+++ b/src/supplement/retrieve-targets.ts
@@ -1,17 +1,23 @@
 /**
- * Build retrieve targets for the Musubi 2-segment cross-plane API.
+ * Build retrieve targets for the Musubi cross-plane API.
  *
- * The server accepts a 2-segment namespace (`tenant/presence`) plus a
- * `planes` array and expands each plane internally (`<namespace>/<plane>`),
- * merging results by score. This collapses N×M per-plane calls into
- * N calls where N is the number of unique base namespaces.
+ * Per Musubi ADR 0031 (wildcard namespace segments) and ADR 0030
+ * (agent-as-tenant), this plugin reads tenant-wide: a single 2-segment
+ * `tenant/*` namespace with a `planes` list spans every channel the
+ * agent has captured into. The server expands `*` against the live
+ * Qdrant payload and merges results by score.
  *
  * Typical case (default supplement planes):
- *   - base "eric/openclaw"  → planes ["curated", "concept"]
- *   - base "eric/_shared"   → planes ["curated", "concept"]
+ *   - base "nyla/*"  → planes ["curated", "concept"]
  *
- * The shared base is derived from `curatedReadScope` entries whose
- * prefix differs from the primary presence.
+ * `nyla/*` subsumes the tenant's per-channel slots (`nyla/voice/*`,
+ * `nyla/openclaw/*`) AND its `nyla/_shared/*` shared-knowledge slot —
+ * one HTTP call covers them all. Each result row carries its concrete
+ * stored namespace so callers can still tell *where* a memory came
+ * from ("on our last call", "in the Openclaw thread").
+ *
+ * Writes still target the channel-tagged 3-segment slot from
+ * `presence.namespaces.episodic`/etc — wildcards are read-only.
  */
 
 import type { PresenceContext } from "../presence/resolver.js";
@@ -31,28 +37,10 @@ export function buildRetrieveTargets(
   presence: PresenceContext,
   planes: readonly string[],
 ): RetrieveTarget[] {
-  const primaryBase = presence.presence;
+  // Derive the tenant from the resolved presence (`<owner>/<presence-id>`).
+  // Resolver guarantees a `/` so this split always has a usable [0].
+  const owner = presence.presence.split("/", 1)[0]!;
+  const tenantWildcardBase = `${owner}/*`;
 
-  const targets: RetrieveTarget[] = [{ baseNamespace: primaryBase, planes: [...planes] }];
-
-  // Shared namespaces are full 3-segment paths like "eric/_shared/curated".
-  // Extract unique bases (first two segments) and the planes they host.
-  const sharedBases = new Map<string, Set<string>>();
-  for (const ns of presence.namespaces.curatedReadScope) {
-    const parts = ns.split("/");
-    if (parts.length < 3) continue;
-    const [owner, shared, plane] = parts as [string, string, string, ...string[]];
-    const base = `${owner}/${shared}`;
-    if (base === primaryBase) continue;
-    if (!planes.includes(plane)) continue;
-    const set = sharedBases.get(base) ?? new Set<string>();
-    set.add(plane);
-    sharedBases.set(base, set);
-  }
-
-  for (const [baseNamespace, planeSet] of sharedBases) {
-    targets.push({ baseNamespace, planes: [...planeSet] });
-  }
-
-  return targets;
+  return [{ baseNamespace: tenantWildcardBase, planes: [...planes] }];
 }

--- a/tests/supplement/corpus.test.ts
+++ b/tests/supplement/corpus.test.ts
@@ -249,12 +249,14 @@ describe("createCorpusSupplement", () => {
 
     await supplement.search({ query: "x", agentSessionKey: "aoi" });
 
-    // Cross-plane calls use 2-segment namespaces. For agent "aoi"
-    // the primary base is `eric/aoi`; shared pools use `eric/_shared`.
+    // Per ADR 0031, supplement search fans tenant-wide via `<owner>/*` —
+    // `eric/*` here, regardless of which presence (`eric/openclaw`,
+    // `eric/aoi`) the agent maps to. Server-side wildcard expansion
+    // covers every channel under that tenant in one call.
     expect(calls.length).toBeGreaterThan(0);
     for (const call of calls) {
       const ns: string = JSON.parse(call.body!).namespace;
-      expect(ns === "eric/aoi" || ns === "eric/_shared").toBe(true);
+      expect(ns).toBe("eric/*");
     }
   });
 
@@ -274,12 +276,13 @@ describe("createCorpusSupplement", () => {
 
     await supplement.search({ query: "x" });
 
-    // Default presence "eric/openclaw"; cross-plane calls use the
-    // 2-segment base `eric/openclaw` or shared `eric/_shared`.
+    // Per ADR 0031, corpus search fans tenant-wide via `<owner>/*` —
+    // `eric/*` here. Server-side wildcard expansion subsumes both
+    // `eric/openclaw/*` and `eric/_shared/*` in one call.
     expect(calls.length).toBeGreaterThan(0);
     for (const call of calls) {
       const ns: string = JSON.parse(call.body!).namespace;
-      expect(ns === "eric/openclaw" || ns === "eric/_shared").toBe(true);
+      expect(ns).toBe("eric/*");
     }
   });
 

--- a/tests/supplement/prompt.test.ts
+++ b/tests/supplement/prompt.test.ts
@@ -249,12 +249,13 @@ describe("createPromptSupplement", () => {
 
     await supplement.refresh({ agentId: "aoi" });
 
-    // Cross-plane calls use 2-segment namespaces: primary base
-    // `eric/aoi` and shared pool `eric/_shared`.
+    // Per ADR 0031, refresh fans tenant-wide via `<owner>/*` — `eric/*`
+    // here. Server-side wildcard expansion subsumes both `eric/aoi/*`
+    // and `eric/_shared/*` in one call.
     expect(bodies.length).toBeGreaterThan(0);
     for (const body of bodies) {
       const ns: string = JSON.parse(body!).namespace;
-      expect(ns === "eric/aoi" || ns === "eric/_shared").toBe(true);
+      expect(ns).toBe("eric/*");
     }
   });
 });

--- a/tests/tools/recall.test.ts
+++ b/tests/tools/recall.test.ts
@@ -64,33 +64,32 @@ describe("createRecallTool", () => {
   });
 
   it("test_recall_accepts_plane_filter_and_limit_parameters", async () => {
-    // Canonical retrieve requires one call per (namespace, plane)
-    // target (see `src/tools/recall.ts`). The mock returns the last
-    // scripted response for overflow calls, so a single `{results: []}`
-    // covers every fanout call.
+    // Per Musubi ADR 0031, recall now uses a tenant-wide wildcard base
+    // (`<owner>/*`) for a single 2-segment cross-plane call. The mock
+    // returns the last scripted response for overflow calls if the
+    // implementation ever fans out further.
     const { fetch, calls } = createMockFetch([{ status: 200, body: { results: [] } }]);
     const tool = createRecallTool({ client: makeClient(fetch), config: makeConfig() });
 
     await tool.definition.execute("c1", { query: "x", planes: ["curated"], limit: 3 });
     const curatedOnly = calls.splice(0, calls.length);
-    // `planes: ["curated"]` → one or two 2-segment calls
-    // (primary base + shared pool), each with `planes: ["curated"]`.
     expect(curatedOnly.length).toBeGreaterThan(0);
     for (const call of curatedOnly) {
       const body = JSON.parse(call.body!);
       expect(body.planes).toEqual(["curated"]);
       expect(body.limit).toBe(3);
+      // 2-segment wildcard base: `<owner>/*`.
       expect(body.namespace.split("/")).toHaveLength(2);
+      expect(body.namespace.endsWith("/*")).toBe(true);
     }
 
     await tool.definition.execute("c2", { query: "x" });
-    // Default: 2-segment cross-plane calls. Primary base gets all
-    // three planes; shared base gets curated + concept.
     const defaultFanout = calls;
     expect(defaultFanout.length).toBeGreaterThan(0);
     for (const call of defaultFanout) {
       const body = JSON.parse(call.body!);
       expect(body.namespace.split("/")).toHaveLength(2);
+      expect(body.namespace.endsWith("/*")).toBe(true);
       expect(body.planes.length).toBeGreaterThanOrEqual(1);
       expect(body.limit).toBe(10);
     }
@@ -147,11 +146,13 @@ describe("createRecallTool", () => {
 
     await tool.definition.execute("c", { query: "x" });
 
-    // Cross-plane calls use 2-segment namespaces. Primary base is
-    // `eric/aoi`; shared pool is `eric/_shared`.
+    // Per ADR 0031, recall fans tenant-wide via `<owner>/*` — `eric/*`
+    // here, regardless of which presence the agent maps to. Wildcard
+    // expansion on the server covers `eric/aoi/*` AND `eric/_shared/*`
+    // in one call.
     for (const call of calls) {
       const ns: string = JSON.parse(call.body!).namespace;
-      expect(ns === "eric/aoi" || ns === "eric/_shared").toBe(true);
+      expect(ns).toBe("eric/*");
     }
   });
 


### PR DESCRIPTION
## Summary

Aligns the plugin with Musubi v1.1.0 ([ADR 0031](https://github.com/ericmey/musubi/blob/main/docs/Musubi/13-decisions/0031-retrieve-wildcard-namespace.md)) — retrieve targets switch from `<owner>/<presence>` + `<owner>/_shared` fanout to a single `<owner>/*` wildcard base.

## Effect

An Openclaw-Nyla `musubi_recall` now spans every channel under the tenant: voice captures, openclaw captures, future Discord captures all surface from one HTTP call. Each result row carries its concrete stored namespace so the agent still knows where a memory came from ("on our last call" vs "in the Openclaw thread").

Writes are unchanged — captures still target the channel-tagged 3-segment slot from `presence.namespaces.episodic`.

## Why now

Foundational platform behavior. The thing Eric tested ("can Openclaw Nyla remember my voice call?") only works once the plugin reads tenant-wide.

## Order of operations

1. Musubi v1.1.0 deploys (ADR 0031 wildcards).
2. This plugin PR merges + reinstalls.
3. Reload Openclaw — multimodality online.

## Test plan

- [x] `pnpm test` — 131 passed
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] Manual smoke after Musubi v1.1.0 deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)