### PR TITLE
feat(tools): musubi_get — fetch one object by id across any plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ replace it. Instead it:
 - **Supplements** the memory prompt with Musubi's curated knowledge and
   synthesized concepts, labeled with provenance so the model weighs
   authoritative sources higher than raw episodic chatter.
-- **Exposes tools** — `musubi_recall`, `musubi_remember`, `musubi_think` —
-  for explicit deep-path queries and presence-to-presence communication.
+- **Exposes tools** — `musubi_recall`, `musubi_get`, `musubi_remember`,
+  `musubi_think` — for explicit deep-path queries, drill-into-source by id,
+  and presence-to-presence communication.
 - **Streams thoughts** inbound over Server-Sent Events so a thought sent by
   your Claude Code session surfaces in your Discord-facing agent within
   seconds, not polling-intervals.

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -168,6 +168,10 @@ plugin depends on it and will not add "only one tab should receive" logic.
   (must return within the prompt-build latency budget).
 - `POST /v1/retrieve` with `mode: "deep"` for the explicit `musubi_recall`
   tool (agent-triggered, no strict latency budget).
+- `GET /v1/{plane}/{object_id}?namespace=…` for the explicit `musubi_get`
+  tool — fetch one object's full content by id after a recall surfaces a
+  load-bearing snippet. Plane path is `curated`, `concepts`, `episodic`,
+  or `artifacts` (matching the canonical router prefixes).
 
 ### Planes
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -74,13 +74,16 @@ episodic plane. This is the flywheel: every OpenClaw modality feeds the
 shared memory automatically, without agents needing to remember to call a
 tool.
 
-### 4. Recall / remember / think tools
+### 4. Recall / get / remember / think tools
 
-Three tools for explicit deep-path work:
+Four tools for explicit deep-path work:
 
 - `musubi_recall` — hybrid retrieve across all planes with full score + rerank.
   Slower than the supplement but richer; agents call it when the supplement
   misses or when they need artifacts.
+- `musubi_get` — fetch one object's full content + metadata by id after a
+  recall snippet looks load-bearing. Read-only `GET` per plane; the agent
+  copies `(plane, namespace, object_id)` straight from the recall row.
 - `musubi_remember` — explicit episodic capture with importance + topics.
   Lets agents pin something as "this matters" beyond the default mirror.
 - `musubi_think` — send a thought to another presence. "Tell my Claude Code

--- a/docs/architecture/wiring.md
+++ b/docs/architecture/wiring.md
@@ -55,6 +55,7 @@ regression surfaces immediately:
 registerMemoryCorpusSupplement
 registerMemoryPromptSupplement
 registerTool:musubi_recall
+registerTool:musubi_get
 registerTool:musubi_remember
 registerTool:musubi_think
 on:agent_end

--- a/docs/decisions/0001-sidecar-with-authority.md
+++ b/docs/decisions/0001-sidecar-with-authority.md
@@ -53,9 +53,9 @@ Musubi runs alongside OpenClaw's native memory engine. The plugin:
   treats it with appropriate weight.
 - Hooks OpenClaw's memory-write events to **mirror every capture** into
   Musubi's episodic plane, giving cross-modality continuity.
-- Exposes explicit tools (`musubi_recall`, `musubi_remember`,
-  `musubi_think`) for agent-triggered deep queries and cross-presence
-  thoughts that the supplement cannot replace.
+- Exposes explicit tools (`musubi_recall`, `musubi_get`, `musubi_remember`,
+  `musubi_think`) for agent-triggered deep queries, drill-into-source by
+  id, and cross-presence thoughts that the supplement cannot replace.
 
 "Authority" here is **soft authority via labeled provenance**, not runtime
 override. The plugin frames its contributions so the model weighs them

--- a/src/plugin/bootstrap.ts
+++ b/src/plugin/bootstrap.ts
@@ -29,6 +29,7 @@ import type { FetchLike } from "../musubi/types.js";
 import { createCorpusSupplement } from "../supplement/corpus.js";
 import { createPromptSupplement } from "../supplement/prompt.js";
 import { createThoughtStream, type ThoughtStream } from "../thoughts/stream.js";
+import { createGetTool } from "../tools/get.js";
 import { createRecallTool } from "../tools/recall.js";
 import { createRememberTool } from "../tools/remember.js";
 import { createThinkTool } from "../tools/think.js";
@@ -158,6 +159,10 @@ export async function bootstrap(options: BootstrapOptions): Promise<LifecycleHan
   api.registerTool(
     (ctx: { agentId?: string }) =>
       createRecallTool({ client, config, agentId: ctx.agentId }).definition,
+  );
+  api.registerTool(
+    (ctx: { agentId?: string }) =>
+      createGetTool({ client, config, agentId: ctx.agentId }).definition,
   );
   api.registerTool(
     (ctx: { agentId?: string }) =>

--- a/src/tools/get.ts
+++ b/src/tools/get.ts
@@ -1,0 +1,188 @@
+import type { MusubiConfig } from "../config.js";
+import type { MusubiClient } from "../musubi/client.js";
+import { MusubiError, NotFoundError } from "../musubi/errors.js";
+import { resolvePresence } from "../presence/resolver.js";
+import { GetParameters, type GetParams } from "./parameters.js";
+
+/**
+ * Agent-callable fetch-by-id across every Musubi plane.
+ *
+ * `recall` returns ranked snippets — useful when the agent is exploring
+ * but lossy when they want to ground a turn on the actual content of one
+ * specific object. `get` is the deep-link companion: take the
+ * `(plane, namespace, object_id)` triple from a recall row and pull the
+ * full underlying object back, with all its metadata, so the agent can
+ * speak about source instead of paraphrase.
+ *
+ * Read-only. Hits the existing per-plane GET endpoints
+ * (`/v1/curated/{id}`, `/v1/concepts/{id}`, `/v1/episodic/{id}`,
+ * `/v1/artifacts/{id}`) — no backend work required.
+ */
+
+export type ToolDefinition = {
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: typeof GetParameters;
+  execute(toolCallId: string, params: GetParams): Promise<ToolResult>;
+};
+
+export type ToolResult = {
+  readonly content: ReadonlyArray<{ type: "text"; text: string }>;
+  readonly isError?: boolean;
+};
+
+export type CreateGetToolOptions = {
+  readonly client: MusubiClient;
+  readonly config: MusubiConfig;
+  /** OpenClaw agent id for presence resolution. */
+  readonly agentId?: string;
+};
+
+export type GetTool = {
+  readonly definition: ToolDefinition;
+  /** Hint to the wiring slice: this tool is opt-in per-agent, not required. */
+  readonly recommendedOptional: true;
+};
+
+/**
+ * Map plane → API path prefix. Curated and episodic are singular in the
+ * canonical API; concept and artifact are plural. Hard-coded here so the
+ * agent never needs to know the pluralization rule.
+ */
+const PLANE_PATH: Record<GetParams["plane"], string> = {
+  curated: "/v1/curated",
+  concept: "/v1/concepts",
+  episodic: "/v1/episodic",
+  artifact: "/v1/artifacts",
+};
+
+export function createGetTool(options: CreateGetToolOptions): GetTool {
+  const { client, config, agentId } = options;
+
+  return {
+    recommendedOptional: true,
+    definition: {
+      name: "musubi_get",
+      description:
+        "Fetch the full content + metadata of one Musubi object by id. Use after `musubi_recall` when a snippet looks load-bearing and the agent needs to drill into the source. Pass the `plane`, `namespace`, and `object_id` straight from the recall result.",
+      parameters: GetParameters,
+      async execute(_toolCallId, params) {
+        let presence;
+        try {
+          presence = resolvePresence(config, { agentId });
+        } catch (err) {
+          return toolError(`Presence unresolved: ${errorMessage(err)}`);
+        }
+
+        const path = `${PLANE_PATH[params.plane]}/${encodeURIComponent(params.object_id)}`;
+
+        try {
+          const row = await client.getWithQuery<Record<string, unknown>>(
+            path,
+            { namespace: params.namespace },
+            { token: presence.token },
+          );
+          return toolText(formatObject(params.plane, params.namespace, params.object_id, row));
+        } catch (err) {
+          if (err instanceof NotFoundError) {
+            return toolError(
+              `Musubi has no ${params.plane} object ${params.object_id} in namespace ${params.namespace}.`,
+            );
+          }
+          return toolError(`Musubi get failed: ${errorMessage(err)}`);
+        }
+      },
+    },
+  };
+}
+
+/**
+ * Render a fetched object for the agent. Prints a stable header line so
+ * the agent can cite the source ([plane] namespace/object_id), then a
+ * compact metadata block of fields the canonical API consistently
+ * returns, and finally the body content. Unknown extra fields are
+ * appended in stable key order so plane-specific shapes (vault_path,
+ * event_at, participants, blob refs, etc.) round-trip without this tool
+ * having to know each plane's schema.
+ */
+function formatObject(
+  plane: GetParams["plane"],
+  namespace: string,
+  objectId: string,
+  row: Record<string, unknown>,
+): string {
+  const lines: string[] = [];
+  lines.push(`[${plane}] ${namespace}/${objectId}`);
+  lines.push("");
+
+  const headerKeys = [
+    "title",
+    "state",
+    "importance",
+    "event_at",
+    "ingested_at",
+    "created_at",
+    "updated_at",
+    "modality",
+    "source_context",
+    "vault_path",
+    "topics",
+    "tags",
+    "participants",
+  ];
+  const seen = new Set<string>(["namespace", "object_id", "content", "summary", "body"]);
+  for (const key of headerKeys) {
+    if (!(key in row)) continue;
+    seen.add(key);
+    const value = row[key];
+    if (value === null || value === undefined) continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    lines.push(`${key}: ${renderValue(value)}`);
+  }
+
+  const extraKeys = Object.keys(row)
+    .filter((k) => !seen.has(k))
+    .sort();
+  for (const key of extraKeys) {
+    const value = row[key];
+    if (value === null || value === undefined) continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    lines.push(`${key}: ${renderValue(value)}`);
+  }
+
+  const content = pickContent(row);
+  if (content !== undefined) {
+    lines.push("");
+    lines.push(content);
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function pickContent(row: Record<string, unknown>): string | undefined {
+  if (typeof row.content === "string") return row.content;
+  if (typeof row.body === "string") return row.body;
+  if (typeof row.summary === "string") return row.summary;
+  return undefined;
+}
+
+function renderValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) return value.map((v) => renderValue(v)).join(", ");
+  return JSON.stringify(value);
+}
+
+function toolText(text: string): ToolResult {
+  return { content: [{ type: "text", text }] };
+}
+
+function toolError(text: string): ToolResult {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof MusubiError) return `${err.name}: ${err.message}`;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/src/tools/parameters.ts
+++ b/src/tools/parameters.ts
@@ -61,6 +61,28 @@ export const RememberParameters = Type.Object(
   { additionalProperties: false },
 );
 
+export const GetParameters = Type.Object(
+  {
+    plane: Type.Union(
+      PLANE_ENUM.map((p) => Type.Literal(p)),
+      {
+        description:
+          "Which plane the object lives in. Recall results expose this as the `[plane]` label.",
+      },
+    ),
+    namespace: Type.String({
+      minLength: 1,
+      description:
+        "Namespace the object belongs to, exactly as returned by recall (e.g. 'eric/aoi-phone/episodic' or 'eric/_shared/curated').",
+    }),
+    object_id: Type.String({
+      minLength: 1,
+      description: "Stable id of the object — copy verbatim from a recall result.",
+    }),
+  },
+  { additionalProperties: false },
+);
+
 export const ThinkParameters = Type.Object(
   {
     toPresence: Type.String({
@@ -91,3 +113,4 @@ export const ThinkParameters = Type.Object(
 export type RecallParams = Static<typeof RecallParameters>;
 export type RememberParams = Static<typeof RememberParameters>;
 export type ThinkParams = Static<typeof ThinkParameters>;
+export type GetParams = Static<typeof GetParameters>;

--- a/tests/plugin/bootstrap.test.ts
+++ b/tests/plugin/bootstrap.test.ts
@@ -179,11 +179,11 @@ describe("bootstrap: capability registration", () => {
     expect(hook).toBeDefined();
   });
 
-  it("registers all three agent tools: recall, remember, think", async () => {
+  it("registers all four agent tools: recall, get, remember, think", async () => {
     const api = makeApi();
     await bootstrap(commonOpts(api));
     const tools = api.events.filter((e) => e.kind === "registerTool");
-    expect(tools).toHaveLength(3);
+    expect(tools).toHaveLength(4);
     const names = tools
       .map((t) => {
         const arg = t.arg as unknown;
@@ -196,7 +196,7 @@ describe("bootstrap: capability registration", () => {
         return tool.name;
       })
       .sort();
-    expect(names).toEqual(["musubi_recall", "musubi_remember", "musubi_think"]);
+    expect(names).toEqual(["musubi_get", "musubi_recall", "musubi_remember", "musubi_think"]);
   });
 });
 
@@ -293,6 +293,7 @@ describe("bootstrap: integration wiring", () => {
       "registerMemoryCorpusSupplement",
       "registerMemoryPromptSupplement",
       "registerTool:musubi_recall",
+      "registerTool:musubi_get",
       "registerTool:musubi_remember",
       "registerTool:musubi_think",
       "on:agent_end",

--- a/tests/tools/get.test.ts
+++ b/tests/tools/get.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from "vitest";
+import { MusubiClient } from "../../src/musubi/client.js";
+import { createGetTool } from "../../src/tools/get.js";
+import type { MusubiConfig } from "../../src/config.js";
+import type { FetchLike } from "../../src/musubi/types.js";
+
+function makeConfig(overrides: Partial<MusubiConfig> = {}): MusubiConfig {
+  return {
+    core: { baseUrl: "https://musubi.test", token: "t", ...(overrides.core ?? {}) },
+    presence: { defaultId: "eric/openclaw", ...(overrides.presence ?? {}) },
+  };
+}
+
+function createMockFetch(script: Array<{ status: number; body?: unknown }>) {
+  const calls: Array<{ url: string; headers: Record<string, string>; body: string | undefined }> =
+    [];
+  let cursor = 0;
+  const fetch: FetchLike = async (url, init) => {
+    const headers: Record<string, string> = {};
+    if (init.headers) {
+      for (const [k, v] of Object.entries(init.headers as Record<string, string>)) {
+        headers[k] = v;
+      }
+    }
+    calls.push({ url, headers, body: typeof init.body === "string" ? init.body : undefined });
+    const def = script[cursor] ?? script[script.length - 1];
+    cursor += 1;
+    if (def === undefined) throw new Error("script exhausted");
+    return new Response(def.body !== undefined ? JSON.stringify(def.body) : null, {
+      status: def.status,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return { fetch, calls };
+}
+
+function makeClient(fetch: FetchLike) {
+  return new MusubiClient({
+    baseUrl: "https://musubi.test",
+    token: "t",
+    fetch,
+    sleep: async () => undefined,
+    random: () => 0,
+    generateRequestId: () => "r",
+    generateIdempotencyKey: () => "auto-idem",
+    retry: { maxAttempts: 1 },
+  });
+}
+
+describe("createGetTool", () => {
+  it("test_get_routes_episodic_to_v1_episodic", async () => {
+    const { fetch, calls } = createMockFetch([
+      {
+        status: 200,
+        body: {
+          object_id: "ep-1",
+          namespace: "eric/aoi-phone/episodic",
+          content: "Eric called from the car.",
+          event_at: "2026-04-29T18:00:00Z",
+          importance: 7,
+          topics: ["car", "phone"],
+        },
+      },
+    ]);
+    const tool = createGetTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("call-1", {
+      plane: "episodic",
+      namespace: "eric/aoi-phone/episodic",
+      object_id: "ep-1",
+    });
+
+    expect(calls[0]?.url).toBe(
+      "https://musubi.test/v1/episodic/ep-1?namespace=eric%2Faoi-phone%2Fepisodic",
+    );
+    expect(result.isError).toBeUndefined();
+    const text = result.content[0]!.text;
+    expect(text).toContain("[episodic] eric/aoi-phone/episodic/ep-1");
+    expect(text).toContain("Eric called from the car.");
+    expect(text).toContain("importance: 7");
+    expect(text).toContain("event_at: 2026-04-29T18:00:00Z");
+    expect(text).toContain("topics: car, phone");
+  });
+
+  it("test_get_routes_each_plane_to_its_pluralization", async () => {
+    const planes = [
+      { plane: "curated", path: "/v1/curated/" },
+      { plane: "concept", path: "/v1/concepts/" },
+      { plane: "episodic", path: "/v1/episodic/" },
+      { plane: "artifact", path: "/v1/artifacts/" },
+    ] as const;
+
+    for (const { plane, path } of planes) {
+      const { fetch, calls } = createMockFetch([
+        { status: 200, body: { object_id: "x", content: "ok" } },
+      ]);
+      const tool = createGetTool({ client: makeClient(fetch), config: makeConfig() });
+      await tool.definition.execute("c", {
+        plane,
+        namespace: "eric/openclaw/episodic",
+        object_id: "x",
+      });
+      expect(calls[0]?.url).toContain(`https://musubi.test${path}x?`);
+    }
+  });
+
+  it("test_get_url_encodes_object_id", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: { content: "ok" } }]);
+    const tool = createGetTool({ client: makeClient(fetch), config: makeConfig() });
+
+    await tool.definition.execute("c", {
+      plane: "curated",
+      namespace: "eric/_shared/curated",
+      object_id: "path/with slash & space",
+    });
+
+    expect(calls[0]?.url).toBe(
+      "https://musubi.test/v1/curated/path%2Fwith%20slash%20%26%20space?namespace=eric%2F_shared%2Fcurated",
+    );
+  });
+
+  it("test_get_uses_per_agent_token_for_presence", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: { content: "ok" } }]);
+    const tool = createGetTool({
+      client: makeClient(fetch),
+      config: makeConfig({
+        core: {
+          baseUrl: "https://musubi.test",
+          token: "default-token",
+          perAgentTokens: { aoi: "aoi-token" },
+        },
+        presence: { defaultId: "eric/openclaw", perAgent: { aoi: "eric/aoi" } },
+      }),
+      agentId: "aoi",
+    });
+
+    await tool.definition.execute("c", {
+      plane: "episodic",
+      namespace: "eric/aoi/episodic",
+      object_id: "ep-1",
+    });
+
+    expect(calls[0]?.headers["Authorization"]).toBe("Bearer aoi-token");
+  });
+
+  it("test_get_404_returns_tool_error_with_clear_message", async () => {
+    const { fetch } = createMockFetch([{ status: 404, body: { detail: "not found" } }]);
+    const tool = createGetTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", {
+      plane: "episodic",
+      namespace: "eric/openclaw/episodic",
+      object_id: "missing",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("no episodic object missing");
+    expect(result.content[0]?.text).toContain("eric/openclaw/episodic");
+  });
+
+  it("test_get_5xx_returns_generic_tool_error", async () => {
+    const { fetch } = createMockFetch([{ status: 500, body: { error: "boom" } }]);
+    const tool = createGetTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", {
+      plane: "episodic",
+      namespace: "eric/openclaw/episodic",
+      object_id: "x",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("Musubi get failed");
+  });
+
+  it("test_get_renders_curated_specific_fields", async () => {
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        body: {
+          object_id: "cur-1",
+          title: "Aoi voice & temperament",
+          state: "matured",
+          vault_path: "world/identity/aoi.md",
+          topics: ["aoi", "voice"],
+          body: "She is the quiet fire.",
+        },
+      },
+    ]);
+    const tool = createGetTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", {
+      plane: "curated",
+      namespace: "eric/_shared/curated",
+      object_id: "cur-1",
+    });
+
+    const text = result.content[0]!.text;
+    expect(text).toContain("title: Aoi voice & temperament");
+    expect(text).toContain("vault_path: world/identity/aoi.md");
+    expect(text).toContain("state: matured");
+    // body falls back to content when `content` is absent
+    expect(text).toContain("She is the quiet fire.");
+  });
+
+  it("test_get_falls_back_to_summary_when_no_body_or_content", async () => {
+    const { fetch } = createMockFetch([
+      { status: 200, body: { object_id: "x", summary: "Short summary." } },
+    ]);
+    const tool = createGetTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", {
+      plane: "concept",
+      namespace: "eric/_shared/concept",
+      object_id: "x",
+    });
+
+    expect(result.content[0]!.text).toContain("Short summary.");
+  });
+
+  it("test_get_omits_namespace_and_object_id_keys_from_metadata_block", async () => {
+    // Header line already prints `[plane] namespace/object_id` — no need
+    // to repeat them in the metadata key list.
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        body: {
+          object_id: "ep-1",
+          namespace: "eric/aoi-phone/episodic",
+          content: "x",
+          importance: 5,
+        },
+      },
+    ]);
+    const tool = createGetTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", {
+      plane: "episodic",
+      namespace: "eric/aoi-phone/episodic",
+      object_id: "ep-1",
+    });
+
+    const text = result.content[0]!.text;
+    // Header line is fine.
+    expect(text.startsWith("[episodic] eric/aoi-phone/episodic/ep-1")).toBe(true);
+    // But no `namespace: ...` or `object_id: ...` rendered as metadata rows.
+    expect(text).not.toMatch(/^namespace:/m);
+    expect(text).not.toMatch(/^object_id:/m);
+  });
+
+  it("test_get_presence_resolution_failure_is_tool_error", async () => {
+    // Strict-mode-like failure: agent has presence mapping but no token.
+    const { fetch } = createMockFetch([{ status: 200, body: {} }]);
+    const tool = createGetTool({
+      client: makeClient(fetch),
+      config: makeConfig({
+        core: { baseUrl: "https://musubi.test", token: "" },
+        presence: { defaultId: "eric/openclaw" },
+      }),
+    });
+
+    const result = await tool.definition.execute("c", {
+      plane: "episodic",
+      namespace: "eric/openclaw/episodic",
+      object_id: "x",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("Presence unresolved");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `musubi_get`, a fourth agent-callable tool. Fetches the full content + metadata of one Musubi object by id, given the `(plane, namespace, object_id)` triple from a `musubi_recall` row.

## Why

Aoi (and any other agent on this plugin) currently has `musubi_recall` for ranked snippets, but no way to drill into one of them. When a recall result looks load-bearing, the agent has to paraphrase from the snippet because there's no fetch-by-id surface — restricting depth and dialogue.

`recall` is the search; `get` is the deep-link.

## Design

- Read-only. Hits the existing per-plane `GET /v1/{plane}/{object_id}?namespace=…` endpoints — **no backend work required**.
- Three required params: `plane` (literal enum), `namespace`, `object_id`. The agent has all three from any recall row, so no inference fragility.
- Plane → path: `curated → /v1/curated`, `concept → /v1/concepts`, `episodic → /v1/episodic`, `artifact → /v1/artifacts`. Hard-coded so agents never deal with the pluralization rule.
- Output: stable `[plane] namespace/object_id` header, then a metadata block of canonical fields (`title`, `state`, `importance`, `event_at`, `vault_path`, `topics`, …) printed only when present, then the body via a `content → body → summary` fallback chain. Plane-specific fields round-trip without this tool needing per-plane schemas.
- 404 → tool error with a clear "no `<plane>` object `<id>` in namespace `<ns>`" message. Other errors → generic tool error.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 141 pass, 5 skipped (pre-existing). 9 new tests in `tests/tools/get.test.ts` covering per-plane routing, URL encoding, per-agent token resolution, 404, 5xx, plane-specific field rendering, content fallback chain, no-duplicate metadata keys, and presence-resolution failure.
- [x] Bootstrap integration test updated: 4-tool registration order + count.

## Docs touched

- `README.md` — tool list now includes `musubi_get`
- `docs/architecture/overview.md` — section 4 retitled to "Recall / get / remember / think tools"
- `docs/architecture/wiring.md` — registration trace shows `registerTool:musubi_get`
- `docs/decisions/0001-sidecar-with-authority.md` — explicit-tools list updated
- `docs/api-contract.md` — read-path expectations document the new `GET /v1/{plane}/{object_id}` usage

## Follow-up (separate PR)

`musubi_recent` — recency-anchored cross-modal "what was the user just doing?" tool. Needs a backend slice in `musubi/` first (current retrieve modes all require a query; no time-ordered no-query path exists yet). Will be authored as a slice in the Musubi vault and shipped through the slice discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)