### PR TITLE
feat(tools): canonical agent-tools conformance — musubi_search + musubi_recent

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ replace it. Instead it:
 - **Supplements** the memory prompt with Musubi's curated knowledge and
   synthesized concepts, labeled with provenance so the model weighs
   authoritative sources higher than raw episodic chatter.
-- **Exposes tools** — `musubi_recall`, `musubi_get`, `musubi_remember`,
-  `musubi_think` — for explicit deep-path queries, drill-into-source by id,
-  and presence-to-presence communication.
+- **Exposes the canonical agent-tools surface** — `musubi_recent`,
+  `musubi_search`, `musubi_get`, `musubi_remember`, `musubi_think` — the
+  same five tools every Musubi adapter exposes (MCP, LiveKit, OpenClaw)
+  per ADR 0032. Plus `musubi_recall` as a one-release deprecation alias
+  for `musubi_search`.
 - **Streams thoughts** inbound over Server-Sent Events so a thought sent by
   your Claude Code session surfaces in your Discord-facing agent within
   seconds, not polling-intervals.

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -166,8 +166,13 @@ plugin depends on it and will not add "only one tab should receive" logic.
 
 - `POST /v1/retrieve` with `mode: "fast"` for prompt-supplement reads
   (must return within the prompt-build latency budget).
-- `POST /v1/retrieve` with `mode: "deep"` for the explicit `musubi_recall`
-  tool (agent-triggered, no strict latency budget).
+- `POST /v1/retrieve` with `mode: "deep"` for the explicit `musubi_search`
+  tool (agent-triggered, no strict latency budget). `musubi_recall` is
+  the one-release deprecation alias that hits the same endpoint.
+- `GET /v1/episodic?namespace=…&limit=…` for the `musubi_recent` tool's
+  presence-scoped fallback. Cross-modal scope (`<tenant>/*/episodic`)
+  lights up when Musubi ships `mode=recent` (slice-retrieve-recent / #288)
+  and the wildcard-namespace primitive (slice-api-retrieve-wildcards).
 - `GET /v1/{plane}/{object_id}?namespace=…` for the explicit `musubi_get`
   tool — fetch one object's full content by id after a recall surfaces a
   load-bearing snippet. Plane path is `curated`, `concepts`, `episodic`,

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -74,20 +74,31 @@ episodic plane. This is the flywheel: every OpenClaw modality feeds the
 shared memory automatically, without agents needing to remember to call a
 tool.
 
-### 4. Recall / get / remember / think tools
+### 4. Canonical agent-tools surface
 
-Four tools for explicit deep-path work:
+Per Musubi ADR 0032, the plugin exposes the five-tool canonical surface
+every adapter implements identically (MCP, LiveKit, OpenClaw):
 
-- `musubi_recall` — hybrid retrieve across all planes with full score + rerank.
-  Slower than the supplement but richer; agents call it when the supplement
-  misses or when they need artifacts.
-- `musubi_get` — fetch one object's full content + metadata by id after a
-  recall snippet looks load-bearing. Read-only `GET` per plane; the agent
-  copies `(plane, namespace, object_id)` straight from the recall row.
+- `musubi_recent` — recency-ordered episodic, no query needed. The
+  "what was I just doing?" tool. Today scoped to the calling presence's
+  own episodic stream; cross-modal (`<tenant>/*/episodic`) lights up
+  when Musubi `slice-retrieve-recent` (#288) and `slice-api-retrieve-
+  wildcards` ship.
+- `musubi_search` — hybrid retrieve across all planes with full score
+  + rerank. Slower than the supplement but richer; agents call it when
+  the supplement misses or when they need artifacts.
+- `musubi_get` — fetch one object's full content + metadata by id after
+  a search snippet looks load-bearing. Read-only `GET` per plane; the
+  agent copies `(plane, namespace, object_id)` straight from the search
+  row.
 - `musubi_remember` — explicit episodic capture with importance + topics.
   Lets agents pin something as "this matters" beyond the default mirror.
-- `musubi_think` — send a thought to another presence. "Tell my Claude Code
-  session that the deploy is done."
+- `musubi_think` — send a thought to another presence. "Tell my Claude
+  Code session that the deploy is done."
+
+Plus `musubi_recall` as a one-release deprecation alias for
+`musubi_search` — emits a logger.warn on each call and forwards to the
+canonical body. Drops in the next minor release.
 
 ### 5. SSE thought consumer
 

--- a/docs/architecture/wiring.md
+++ b/docs/architecture/wiring.md
@@ -54,10 +54,12 @@ regression surfaces immediately:
 ```
 registerMemoryCorpusSupplement
 registerMemoryPromptSupplement
-registerTool:musubi_recall
+registerTool:musubi_search
+registerTool:musubi_recent
 registerTool:musubi_get
 registerTool:musubi_remember
 registerTool:musubi_think
+registerTool:musubi_recall
 on:agent_end
 ```
 

--- a/docs/decisions/0001-sidecar-with-authority.md
+++ b/docs/decisions/0001-sidecar-with-authority.md
@@ -53,9 +53,11 @@ Musubi runs alongside OpenClaw's native memory engine. The plugin:
   treats it with appropriate weight.
 - Hooks OpenClaw's memory-write events to **mirror every capture** into
   Musubi's episodic plane, giving cross-modality continuity.
-- Exposes explicit tools (`musubi_recall`, `musubi_get`, `musubi_remember`,
-  `musubi_think`) for agent-triggered deep queries, drill-into-source by
-  id, and cross-presence thoughts that the supplement cannot replace.
+- Exposes the canonical agent-tools surface (`musubi_recent`,
+  `musubi_search`, `musubi_get`, `musubi_remember`, `musubi_think`) per
+  Musubi ADR 0032 — agent-triggered recency, deep queries, drill-into-
+  source by id, explicit captures, and cross-presence thoughts. Plus
+  `musubi_recall` as a one-release deprecation alias for `musubi_search`.
 
 "Authority" here is **soft authority via labeled provenance**, not runtime
 override. The plugin frames its contributions so the model weighs them

--- a/src/plugin/bootstrap.ts
+++ b/src/plugin/bootstrap.ts
@@ -31,7 +31,9 @@ import { createPromptSupplement } from "../supplement/prompt.js";
 import { createThoughtStream, type ThoughtStream } from "../thoughts/stream.js";
 import { createGetTool } from "../tools/get.js";
 import { createRecallTool } from "../tools/recall.js";
+import { createRecentTool } from "../tools/recent.js";
 import { createRememberTool } from "../tools/remember.js";
+import { createSearchTool } from "../tools/search.js";
 import { createThinkTool } from "../tools/think.js";
 import {
   createIntervalScheduler,
@@ -156,9 +158,16 @@ export async function bootstrap(options: BootstrapOptions): Promise<LifecycleHan
   // agent's identity from OpenClaw's runtime context. Static tool
   // registration captures the default presence once at load time,
   // which breaks per-agent token isolation.
+  // Canonical agent-tools surface per ADR 0032 — five tools every Musubi
+  // adapter exposes identically. Plus the one-release deprecation alias
+  // `musubi_recall` → `musubi_search`.
   api.registerTool(
     (ctx: { agentId?: string }) =>
-      createRecallTool({ client, config, agentId: ctx.agentId }).definition,
+      createSearchTool({ client, config, agentId: ctx.agentId }).definition,
+  );
+  api.registerTool(
+    (ctx: { agentId?: string }) =>
+      createRecentTool({ client, config, agentId: ctx.agentId }).definition,
   );
   api.registerTool(
     (ctx: { agentId?: string }) =>
@@ -171,6 +180,16 @@ export async function bootstrap(options: BootstrapOptions): Promise<LifecycleHan
   api.registerTool(
     (ctx: { agentId?: string }) =>
       createThinkTool({ client, config, agentId: ctx.agentId }).definition,
+  );
+  // Deprecation alias — drops in the next minor release.
+  api.registerTool(
+    (ctx: { agentId?: string }) =>
+      createRecallTool({
+        client,
+        config,
+        agentId: ctx.agentId,
+        logger: { warn: (msg) => api.logger.warn(msg) },
+      }).definition,
   );
 
   // `agent_end` → `capture-mirror.handleEvent`. Failures are swallowed

--- a/src/tools/parameters.ts
+++ b/src/tools/parameters.ts
@@ -9,7 +9,14 @@ import { Type, type Static } from "@sinclair/typebox";
 
 export const PLANE_ENUM = ["curated", "concept", "episodic", "artifact"] as const;
 
-export const RecallParameters = Type.Object(
+/**
+ * Canonical name per [[07-interfaces/agent-tools]] / ADR 0032.
+ *
+ * `musubi_recall` is the legacy name; `RecallParameters` is re-exported
+ * below as an alias so existing call-sites keep compiling during the
+ * one-release deprecation window.
+ */
+export const SearchParameters = Type.Object(
   {
     query: Type.String({
       minLength: 1,
@@ -26,6 +33,35 @@ export const RecallParameters = Type.Object(
         minimum: 1,
         maximum: 50,
         description: "Max rows to return. Defaults to 10.",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+/** @deprecated Use {@link SearchParameters}. Removed after one minor release. */
+export const RecallParameters = SearchParameters;
+
+export const RecentParameters = Type.Object(
+  {
+    limit: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        maximum: 50,
+        description:
+          "Max rows to return. Defaults to 10. Returns the N most recent episodic captures in the agent's presence namespace.",
+      }),
+    ),
+    since: Type.Optional(
+      Type.String({
+        description:
+          "ISO-8601 timestamp lower bound. Returns only rows captured at or after this time. Absent = newest items, no time filter.",
+      }),
+    ),
+    tags: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Filter to rows whose `tags` contains every listed tag. Useful for narrowing to a specific modality (`src:openclaw-agent-remember`) or topic.",
       }),
     ),
   },
@@ -110,7 +146,10 @@ export const ThinkParameters = Type.Object(
   { additionalProperties: false },
 );
 
-export type RecallParams = Static<typeof RecallParameters>;
+export type SearchParams = Static<typeof SearchParameters>;
+/** @deprecated Use {@link SearchParams}. Removed after one minor release. */
+export type RecallParams = SearchParams;
 export type RememberParams = Static<typeof RememberParameters>;
 export type ThinkParams = Static<typeof ThinkParameters>;
 export type GetParams = Static<typeof GetParameters>;
+export type RecentParams = Static<typeof RecentParameters>;

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -1,18 +1,17 @@
 import type { MusubiConfig } from "../config.js";
 import type { MusubiClient } from "../musubi/client.js";
-import { MusubiError } from "../musubi/errors.js";
-import { resolvePresence } from "../presence/resolver.js";
-import { buildRetrieveTargets } from "../supplement/retrieve-targets.js";
 import { RecallParameters, type RecallParams } from "./parameters.js";
+import { executeSearch, type ToolResult } from "./search.js";
 
 /**
- * Agent-callable deep-path retrieval across all planes.
+ * Deprecated agent-callable semantic search tool — `musubi_recall`.
  *
- * The passive `MemoryCorpusSupplement` from slice #4 covers the common
- * case (query-relevant curated + concept rows in fast mode). `recall` is
- * the explicit escape hatch when the supplement missed, or when the
- * agent knows it wants the full hybrid + rerank pipeline across every
- * plane including episodic and artifacts.
+ * Per [[13-decisions/0032-agent-tools-canonical-surface]] the canonical
+ * name is `musubi_search`; `musubi_recall` is a one-release deprecation
+ * alias that forwards to the same body with a warning log so existing
+ * system prompts keep working while we migrate. After the next minor
+ * release this file goes away and `musubi_recall` stops being
+ * advertised.
  */
 
 export type ToolDefinition = {
@@ -22,131 +21,39 @@ export type ToolDefinition = {
   execute(toolCallId: string, params: RecallParams): Promise<ToolResult>;
 };
 
-export type ToolResult = {
-  readonly content: ReadonlyArray<{ type: "text"; text: string }>;
-  readonly isError?: boolean;
-};
-
 export type CreateRecallToolOptions = {
   readonly client: MusubiClient;
   readonly config: MusubiConfig;
-  /** OpenClaw agent id for presence resolution. */
   readonly agentId?: string;
+  /**
+   * Optional logger so the deprecation warning surfaces through the
+   * plugin host's structured-log channel. Falls back to `console.warn`
+   * when not provided so a forgotten wiring still emits a visible signal.
+   */
+  readonly logger?: { warn(message: string): void };
 };
 
 export type RecallTool = {
   readonly definition: ToolDefinition;
-  /** Hint to the wiring slice: this tool is opt-in per-agent, not required. */
   readonly recommendedOptional: true;
 };
 
-const DEFAULT_LIMIT = 10;
-
-type MusubiRetrieveRow = {
-  readonly object_id: string;
-  readonly score: number;
-  readonly plane: string;
-  readonly content: string;
-  readonly namespace: string;
-  readonly title?: string | null;
-};
-
-type MusubiRetrieveResponse = {
-  readonly results: readonly MusubiRetrieveRow[];
-};
-
 export function createRecallTool(options: CreateRecallToolOptions): RecallTool {
-  const { client, config, agentId } = options;
-
+  const { logger } = options;
   return {
     recommendedOptional: true,
     definition: {
       name: "musubi_recall",
       description:
-        "Search Musubi across every plane (curated knowledge, synthesized concepts, episodic memory, source artifacts) using the full hybrid + rerank pipeline. Use when the passive memory supplement didn't surface what you need.",
+        "[DEPRECATED — use musubi_search] Search Musubi across every plane using the full hybrid + rerank pipeline. Removed in the next minor release.",
       parameters: RecallParameters,
       async execute(_toolCallId, params) {
-        let presence;
-        try {
-          presence = resolvePresence(config, { agentId });
-        } catch (err) {
-          return toolError(`Presence unresolved: ${errorMessage(err)}`);
-        }
-
-        const limit = params.limit ?? DEFAULT_LIMIT;
-
-        // Build planes list from caller filter or default readable set.
-        const defaultPlanes = ["curated", "concept", "episodic", "artifact"];
-        const callerPlanes = params.planes ? [...params.planes] : defaultPlanes;
-
-        // Collapse per-plane fanout into 2-segment cross-plane calls.
-        const targets = buildRetrieveTargets(presence, callerPlanes);
-
-        const settled = await Promise.allSettled(
-          targets.map((t) =>
-            client.post<MusubiRetrieveResponse>("/v1/retrieve", {
-              body: {
-                namespace: t.baseNamespace,
-                planes: [...t.planes],
-                query_text: params.query,
-                mode: "deep",
-                limit,
-              },
-              token: presence.token,
-            }),
-          ),
+        const warn = logger?.warn ?? ((m: string) => console.warn(m));
+        warn(
+          "musubi_recall is deprecated; use musubi_search (canonical name per ADR 0032 / agent-tools spec). The alias drops in the next minor release.",
         );
-        if (settled.every((r) => r.status === "rejected")) {
-          const firstErr =
-            settled[0]!.status === "rejected"
-              ? (settled[0] as PromiseRejectedResult).reason
-              : new Error("unknown");
-          return toolError(`Musubi recall failed: ${errorMessage(firstErr)}`);
-        }
-        const seen = new Set<string>();
-        const merged: MusubiRetrieveRow[] = [];
-        for (const result of settled) {
-          if (result.status !== "fulfilled") continue;
-          for (const row of result.value.results ?? []) {
-            if (seen.has(row.object_id)) continue;
-            seen.add(row.object_id);
-            merged.push(row);
-          }
-        }
-        merged.sort((a, b) => b.score - a.score);
-        const results = merged.slice(0, limit);
-        if (results.length === 0) {
-          return toolText(`No Musubi results for "${params.query}".`);
-        }
-        return toolText(formatResults(results));
+        return executeSearch(options, params);
       },
     },
   };
-}
-
-function formatResults(rows: readonly MusubiRetrieveRow[]): string {
-  const lines: string[] = [];
-  lines.push(`Musubi returned ${rows.length} result(s):`);
-  lines.push("");
-  for (const row of rows) {
-    const label = row.title ? `${row.title}` : `${row.namespace}/${row.object_id}`;
-    lines.push(`[${row.plane}] (score ${row.score.toFixed(2)}) ${label}`);
-    lines.push(row.content);
-    lines.push("");
-  }
-  return lines.join("\n").trimEnd();
-}
-
-function toolText(text: string): ToolResult {
-  return { content: [{ type: "text", text }] };
-}
-
-function toolError(text: string): ToolResult {
-  return { content: [{ type: "text", text }], isError: true };
-}
-
-function errorMessage(err: unknown): string {
-  if (err instanceof MusubiError) return `${err.name}: ${err.message}`;
-  if (err instanceof Error) return err.message;
-  return String(err);
 }

--- a/src/tools/recent.ts
+++ b/src/tools/recent.ts
@@ -1,0 +1,189 @@
+import type { MusubiConfig } from "../config.js";
+import type { MusubiClient } from "../musubi/client.js";
+import { MusubiError } from "../musubi/errors.js";
+import { resolvePresence } from "../presence/resolver.js";
+import { RecentParameters, type RecentParams } from "./parameters.js";
+
+/**
+ * Agent-callable recency-anchored episodic recall — `musubi_recent`.
+ *
+ * The agent asks "what's recent?" without supplying a query. Returns
+ * the most recently captured episodic rows from the calling presence's
+ * stream, ordered newest-first.
+ *
+ * **Scope today is presence-only** (`<tenant>/<presence>/episodic`).
+ * Cross-modal scope (`<tenant>/*\/episodic`) lights up when:
+ *   1. `slice-api-retrieve-wildcards` (Musubi #266) ships — wildcard
+ *      namespace primitive on retrieve.
+ *   2. `slice-retrieve-recent` (Musubi #288) ships — `mode=recent`
+ *      bypassing the query-required pipeline.
+ *
+ * Until both land, this fallback paginates `GET /v1/episodic` for the
+ * presence's own namespace and sorts client-side by event timestamp.
+ * The fallback is documented in [[07-interfaces/agent-tools]] and
+ * [[_slices/slice-openclaw-canonical-tools]] § Depends on.
+ */
+
+export type ToolDefinition = {
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: typeof RecentParameters;
+  execute(toolCallId: string, params: RecentParams): Promise<ToolResult>;
+};
+
+export type ToolResult = {
+  readonly content: ReadonlyArray<{ type: "text"; text: string }>;
+  readonly isError?: boolean;
+};
+
+export type CreateRecentToolOptions = {
+  readonly client: MusubiClient;
+  readonly config: MusubiConfig;
+  readonly agentId?: string;
+};
+
+export type RecentTool = {
+  readonly definition: ToolDefinition;
+  readonly recommendedOptional: true;
+};
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+
+type EpisodicRow = {
+  readonly object_id?: string;
+  readonly namespace?: string;
+  readonly content?: string;
+  readonly tags?: readonly string[];
+  readonly event_at?: string;
+  readonly ingested_at?: string;
+  readonly created_at?: string;
+  readonly created_epoch?: number;
+};
+
+type EpisodicPage = {
+  readonly items: readonly EpisodicRow[];
+  readonly next_cursor?: string | null;
+};
+
+export function createRecentTool(options: CreateRecentToolOptions): RecentTool {
+  const { client, config, agentId } = options;
+
+  return {
+    recommendedOptional: true,
+    definition: {
+      name: "musubi_recent",
+      description:
+        "Recent activity from the calling presence's episodic memory, newest-first. No query needed — ask 'what was I just doing?' and the agent gets the last N captures. Cross-modal scope is forthcoming; today, presence-only.",
+      parameters: RecentParameters,
+      async execute(_toolCallId, params) {
+        let presence;
+        try {
+          presence = resolvePresence(config, { agentId });
+        } catch (err) {
+          return toolError(`Presence unresolved: ${errorMessage(err)}`);
+        }
+
+        const limit = Math.min(Math.max(params.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+        const namespace = presence.namespaces.episodic;
+
+        let page: EpisodicPage;
+        try {
+          page = await client.getWithQuery<EpisodicPage>(
+            "/v1/episodic",
+            { namespace, limit },
+            { token: presence.token },
+          );
+        } catch (err) {
+          return toolError(`Musubi recent failed: ${errorMessage(err)}`);
+        }
+
+        let rows: readonly EpisodicRow[] = page.items ?? [];
+
+        // Apply tag filter — every listed tag must be in row.tags.
+        if (params.tags && params.tags.length > 0) {
+          const required = params.tags;
+          rows = rows.filter((r) => required.every((t) => (r.tags ?? []).includes(t)));
+        }
+
+        // Apply since filter — row's primary timestamp >= since.
+        if (params.since) {
+          const sinceMs = Date.parse(params.since);
+          if (!Number.isFinite(sinceMs)) {
+            return toolError(
+              `Invalid 'since' value '${params.since}': expected ISO-8601 timestamp.`,
+            );
+          }
+          rows = rows.filter((r) => {
+            const tsMs = pickTimestampMs(r);
+            return tsMs !== undefined && tsMs >= sinceMs;
+          });
+        }
+
+        // Sort newest-first by event_at (preferred), then created_at,
+        // then created_epoch as last-resort fallback. The API page is
+        // Qdrant-scroll-ordered (undefined), so client-side sort is
+        // load-bearing for "recent" semantics.
+        const sorted = [...rows].sort((a, b) => {
+          const ta = pickTimestampMs(a) ?? 0;
+          const tb = pickTimestampMs(b) ?? 0;
+          return tb - ta;
+        });
+        const top = sorted.slice(0, limit);
+
+        if (top.length === 0) {
+          return toolText(`No recent activity in ${namespace}.`);
+        }
+        return toolText(formatResults(namespace, top));
+      },
+    },
+  };
+}
+
+function pickTimestampMs(row: EpisodicRow): number | undefined {
+  if (row.event_at) {
+    const ms = Date.parse(row.event_at);
+    if (Number.isFinite(ms)) return ms;
+  }
+  if (row.created_at) {
+    const ms = Date.parse(row.created_at);
+    if (Number.isFinite(ms)) return ms;
+  }
+  if (row.ingested_at) {
+    const ms = Date.parse(row.ingested_at);
+    if (Number.isFinite(ms)) return ms;
+  }
+  if (typeof row.created_epoch === "number") {
+    return row.created_epoch * 1000;
+  }
+  return undefined;
+}
+
+function formatResults(namespace: string, rows: readonly EpisodicRow[]): string {
+  const lines: string[] = [];
+  lines.push(`Recent activity (${namespace}, last ${rows.length}):`);
+  lines.push("");
+  for (const row of rows) {
+    const ts = row.event_at ?? row.created_at ?? row.ingested_at ?? "(no timestamp)";
+    const oid = row.object_id ?? "<no-id>";
+    const content = (row.content ?? "").trim();
+    lines.push(`[${ts}] ${namespace}/${oid}`);
+    if (content) lines.push(content);
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd();
+}
+
+function toolText(text: string): ToolResult {
+  return { content: [{ type: "text", text }] };
+}
+
+function toolError(text: string): ToolResult {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof MusubiError) return `${err.name}: ${err.message}`;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,0 +1,162 @@
+import type { MusubiConfig } from "../config.js";
+import type { MusubiClient } from "../musubi/client.js";
+import { MusubiError } from "../musubi/errors.js";
+import { resolvePresence } from "../presence/resolver.js";
+import { buildRetrieveTargets } from "../supplement/retrieve-targets.js";
+import { SearchParameters, type SearchParams } from "./parameters.js";
+
+/**
+ * Canonical agent-callable semantic search tool — `musubi_search`.
+ *
+ * Hybrid + rerank retrieval across every plane the calling presence can
+ * read. The deep-path companion to the passive memory supplement: the
+ * agent invokes this when the supplement missed the load-bearing thing,
+ * or when the agent needs artifact-level grounding.
+ *
+ * This file holds the body. `recall.ts` re-exports the same body wrapped
+ * with a deprecation log under the legacy `musubi_recall` name for
+ * one minor release per [[13-decisions/0032-agent-tools-canonical-surface]].
+ */
+
+export type ToolDefinition = {
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: typeof SearchParameters;
+  execute(toolCallId: string, params: SearchParams): Promise<ToolResult>;
+};
+
+export type ToolResult = {
+  readonly content: ReadonlyArray<{ type: "text"; text: string }>;
+  readonly isError?: boolean;
+};
+
+export type CreateSearchToolOptions = {
+  readonly client: MusubiClient;
+  readonly config: MusubiConfig;
+  /** OpenClaw agent id for presence resolution. */
+  readonly agentId?: string;
+};
+
+export type SearchTool = {
+  readonly definition: ToolDefinition;
+  readonly recommendedOptional: true;
+};
+
+const DEFAULT_LIMIT = 10;
+
+type MusubiRetrieveRow = {
+  readonly object_id: string;
+  readonly score: number;
+  readonly plane: string;
+  readonly content: string;
+  readonly namespace: string;
+  readonly title?: string | null;
+};
+
+type MusubiRetrieveResponse = {
+  readonly results: readonly MusubiRetrieveRow[];
+};
+
+/**
+ * Backing implementation. Exported so the deprecation alias in
+ * `recall.ts` reuses the exact same code path — no parameter or
+ * response drift between canonical and alias.
+ */
+export async function executeSearch(
+  options: CreateSearchToolOptions,
+  params: SearchParams,
+): Promise<ToolResult> {
+  const { client, config, agentId } = options;
+
+  let presence;
+  try {
+    presence = resolvePresence(config, { agentId });
+  } catch (err) {
+    return toolError(`Presence unresolved: ${errorMessage(err)}`);
+  }
+
+  const limit = params.limit ?? DEFAULT_LIMIT;
+  const defaultPlanes = ["curated", "concept", "episodic", "artifact"];
+  const callerPlanes = params.planes ? [...params.planes] : defaultPlanes;
+  const targets = buildRetrieveTargets(presence, callerPlanes);
+
+  const settled = await Promise.allSettled(
+    targets.map((t) =>
+      client.post<MusubiRetrieveResponse>("/v1/retrieve", {
+        body: {
+          namespace: t.baseNamespace,
+          planes: [...t.planes],
+          query_text: params.query,
+          mode: "deep",
+          limit,
+        },
+        token: presence.token,
+      }),
+    ),
+  );
+  if (settled.every((r) => r.status === "rejected")) {
+    const firstErr =
+      settled[0]!.status === "rejected"
+        ? (settled[0] as PromiseRejectedResult).reason
+        : new Error("unknown");
+    return toolError(`Musubi search failed: ${errorMessage(firstErr)}`);
+  }
+  const seen = new Set<string>();
+  const merged: MusubiRetrieveRow[] = [];
+  for (const result of settled) {
+    if (result.status !== "fulfilled") continue;
+    for (const row of result.value.results ?? []) {
+      if (seen.has(row.object_id)) continue;
+      seen.add(row.object_id);
+      merged.push(row);
+    }
+  }
+  merged.sort((a, b) => b.score - a.score);
+  const results = merged.slice(0, limit);
+  if (results.length === 0) {
+    return toolText(`No Musubi results for "${params.query}".`);
+  }
+  return toolText(formatResults(results));
+}
+
+export function createSearchTool(options: CreateSearchToolOptions): SearchTool {
+  return {
+    recommendedOptional: true,
+    definition: {
+      name: "musubi_search",
+      description:
+        "Search Musubi across every plane (curated knowledge, synthesized concepts, episodic memory, source artifacts) using the full hybrid + rerank pipeline. Use when the passive memory supplement didn't surface what you need.",
+      parameters: SearchParameters,
+      async execute(_toolCallId, params) {
+        return executeSearch(options, params);
+      },
+    },
+  };
+}
+
+function formatResults(rows: readonly MusubiRetrieveRow[]): string {
+  const lines: string[] = [];
+  lines.push(`Musubi returned ${rows.length} result(s):`);
+  lines.push("");
+  for (const row of rows) {
+    const label = row.title ? `${row.title}` : `${row.namespace}/${row.object_id}`;
+    lines.push(`[${row.plane}] (score ${row.score.toFixed(2)}) ${label}`);
+    lines.push(row.content);
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd();
+}
+
+function toolText(text: string): ToolResult {
+  return { content: [{ type: "text", text }] };
+}
+
+function toolError(text: string): ToolResult {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof MusubiError) return `${err.name}: ${err.message}`;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/tests/plugin/bootstrap.test.ts
+++ b/tests/plugin/bootstrap.test.ts
@@ -179,11 +179,13 @@ describe("bootstrap: capability registration", () => {
     expect(hook).toBeDefined();
   });
 
-  it("registers all four agent tools: recall, get, remember, think", async () => {
+  it("registers the canonical agent-tools surface plus the recall deprecation alias", async () => {
     const api = makeApi();
     await bootstrap(commonOpts(api));
     const tools = api.events.filter((e) => e.kind === "registerTool");
-    expect(tools).toHaveLength(4);
+    // Five canonical (search/recent/get/remember/think) + one deprecation
+    // alias (recall → search) per ADR 0032 / [[07-interfaces/agent-tools]].
+    expect(tools).toHaveLength(6);
     const names = tools
       .map((t) => {
         const arg = t.arg as unknown;
@@ -196,7 +198,14 @@ describe("bootstrap: capability registration", () => {
         return tool.name;
       })
       .sort();
-    expect(names).toEqual(["musubi_get", "musubi_recall", "musubi_remember", "musubi_think"]);
+    expect(names).toEqual([
+      "musubi_get",
+      "musubi_recall",
+      "musubi_recent",
+      "musubi_remember",
+      "musubi_search",
+      "musubi_think",
+    ]);
   });
 });
 
@@ -292,10 +301,12 @@ describe("bootstrap: integration wiring", () => {
     expect(kinds).toEqual([
       "registerMemoryCorpusSupplement",
       "registerMemoryPromptSupplement",
-      "registerTool:musubi_recall",
+      "registerTool:musubi_search",
+      "registerTool:musubi_recent",
       "registerTool:musubi_get",
       "registerTool:musubi_remember",
       "registerTool:musubi_think",
+      "registerTool:musubi_recall",
       "on:agent_end",
     ]);
   });

--- a/tests/tools/recall.test.ts
+++ b/tests/tools/recall.test.ts
@@ -131,7 +131,10 @@ describe("createRecallTool", () => {
     const result = await tool.definition.execute("call", { query: "x" });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain("Musubi recall failed");
+    // After ADR 0032, `musubi_recall` is a deprecation alias forwarding to
+    // the canonical `musubi_search` body — the user-facing error message
+    // is the canonical one.
+    expect(result.content[0]?.text).toContain("Musubi search failed");
   });
 
   it("uses agent presence when agentId is provided", async () => {
@@ -164,5 +167,27 @@ describe("createRecallTool", () => {
 
     expect(result.isError).toBeFalsy();
     expect(result.content[0]?.text).toContain("No Musubi results");
+  });
+
+  it("logs a deprecation warning on every invocation", async () => {
+    // After ADR 0032, `musubi_recall` is a one-release deprecation alias
+    // for `musubi_search`. Each call must log a warning so prompts /
+    // operators see the migration signal.
+    const { fetch } = createMockFetch([{ status: 200, body: { results: [] } }]);
+    const warnings: string[] = [];
+    const tool = createRecallTool({
+      client: makeClient(fetch),
+      config: makeConfig(),
+      logger: { warn: (msg) => warnings.push(msg) },
+    });
+
+    await tool.definition.execute("c", { query: "x" });
+    await tool.definition.execute("c", { query: "y" });
+
+    expect(warnings).toHaveLength(2);
+    for (const warning of warnings) {
+      expect(warning.toLowerCase()).toContain("deprecated");
+      expect(warning).toMatch(/musubi_recall|musubi_search/);
+    }
   });
 });

--- a/tests/tools/recent.test.ts
+++ b/tests/tools/recent.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+
+import type { MusubiConfig } from "../../src/config.js";
+import { MusubiClient } from "../../src/musubi/client.js";
+import type { FetchLike } from "../../src/musubi/types.js";
+import { createRecentTool } from "../../src/tools/recent.js";
+
+function makeConfig(overrides: Partial<MusubiConfig> = {}): MusubiConfig {
+  return {
+    core: { baseUrl: "https://musubi.test", token: "t", ...(overrides.core ?? {}) },
+    presence: { defaultId: "eric/openclaw", ...(overrides.presence ?? {}) },
+  };
+}
+
+type ScriptedResponse = { status: number; body?: unknown } | { throw: Error };
+
+function createMockFetch(script: ScriptedResponse[]) {
+  const calls: Array<{ url: string; body: string | undefined }> = [];
+  let cursor = 0;
+  const fetch: FetchLike = async (url, init) => {
+    calls.push({ url, body: typeof init.body === "string" ? init.body : undefined });
+    const def = script[cursor] ?? script[script.length - 1];
+    cursor += 1;
+    if (def === undefined) throw new Error("script exhausted");
+    if ("throw" in def) throw def.throw;
+    return new Response(def.body !== undefined ? JSON.stringify(def.body) : null, {
+      status: def.status,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return { fetch, calls };
+}
+
+function makeClient(fetch: FetchLike) {
+  return new MusubiClient({
+    baseUrl: "https://musubi.test",
+    token: "t",
+    fetch,
+    sleep: async () => undefined,
+    random: () => 0,
+    generateRequestId: () => "r",
+    generateIdempotencyKey: () => "i",
+    retry: { maxAttempts: 1 },
+  });
+}
+
+describe("createRecentTool", () => {
+  it("registers as musubi_recent", () => {
+    const { fetch } = createMockFetch([{ status: 200, body: { items: [] } }]);
+    const tool = createRecentTool({ client: makeClient(fetch), config: makeConfig() });
+    expect(tool.definition.name).toBe("musubi_recent");
+    expect(tool.recommendedOptional).toBe(true);
+  });
+
+  it("calls GET /v1/episodic with the presence's episodic namespace", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: { items: [] } }]);
+    const tool = createRecentTool({ client: makeClient(fetch), config: makeConfig() });
+
+    await tool.definition.execute("call", { limit: 5 });
+
+    expect(calls[0]?.url).toBe(
+      "https://musubi.test/v1/episodic?namespace=eric%2Fopenclaw%2Fepisodic&limit=5",
+    );
+  });
+
+  it("orders results newest-first by event_at", async () => {
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        body: {
+          items: [
+            {
+              object_id: "older",
+              namespace: "eric/openclaw/episodic",
+              content: "older capture",
+              event_at: "2026-04-28T10:00:00Z",
+            },
+            {
+              object_id: "newer",
+              namespace: "eric/openclaw/episodic",
+              content: "newer capture",
+              event_at: "2026-04-29T18:00:00Z",
+            },
+          ],
+        },
+      },
+    ]);
+    const tool = createRecentTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", {});
+
+    const text = result.content[0]!.text;
+    // Newer should appear before older in the rendered output.
+    const newerPos = text.indexOf("newer capture");
+    const olderPos = text.indexOf("older capture");
+    expect(newerPos).toBeGreaterThan(-1);
+    expect(olderPos).toBeGreaterThan(-1);
+    expect(newerPos).toBeLessThan(olderPos);
+  });
+
+  it("filters rows by tag — every listed tag must be present", async () => {
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        body: {
+          items: [
+            {
+              object_id: "a",
+              content: "tagged",
+              tags: ["src:openclaw-agent-remember", "important"],
+              event_at: "2026-04-29T18:00:00Z",
+            },
+            {
+              object_id: "b",
+              content: "untagged",
+              tags: ["passive"],
+              event_at: "2026-04-29T17:00:00Z",
+            },
+          ],
+        },
+      },
+    ]);
+    const tool = createRecentTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", {
+      tags: ["src:openclaw-agent-remember"],
+    });
+
+    const text = result.content[0]!.text;
+    expect(text).toContain("tagged");
+    expect(text).not.toContain("untagged");
+  });
+
+  it("applies the since filter — rows older than `since` are excluded", async () => {
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        body: {
+          items: [
+            {
+              object_id: "old",
+              content: "before since",
+              event_at: "2026-04-28T10:00:00Z",
+            },
+            {
+              object_id: "new",
+              content: "after since",
+              event_at: "2026-04-29T18:00:00Z",
+            },
+          ],
+        },
+      },
+    ]);
+    const tool = createRecentTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", { since: "2026-04-29T00:00:00Z" });
+
+    const text = result.content[0]!.text;
+    expect(text).toContain("after since");
+    expect(text).not.toContain("before since");
+  });
+
+  it("rejects invalid `since` value with a clear tool error", async () => {
+    const { fetch } = createMockFetch([
+      { status: 200, body: { items: [{ object_id: "a", content: "x" }] } },
+    ]);
+    const tool = createRecentTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", { since: "not-a-date" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("Invalid 'since'");
+  });
+
+  it("returns a friendly empty-namespace message when no rows match", async () => {
+    const { fetch } = createMockFetch([{ status: 200, body: { items: [] } }]);
+    const tool = createRecentTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", {});
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]?.text).toContain("No recent activity");
+    expect(result.content[0]?.text).toContain("eric/openclaw/episodic");
+  });
+
+  it("surfaces backend error as a tool error string", async () => {
+    const { fetch } = createMockFetch([{ throw: new TypeError("fetch failed") }]);
+    const tool = createRecentTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("Musubi recent failed");
+  });
+
+  it("uses agent presence when agentId is provided", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: { items: [] } }]);
+    const tool = createRecentTool({
+      client: makeClient(fetch),
+      config: makeConfig({
+        presence: { defaultId: "eric/openclaw", perAgent: { aoi: "eric/aoi" } },
+      }),
+      agentId: "aoi",
+    });
+
+    await tool.definition.execute("c", {});
+    expect(calls[0]?.url).toContain("namespace=eric%2Faoi%2Fepisodic");
+  });
+});

--- a/tests/tools/search.test.ts
+++ b/tests/tools/search.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import type { MusubiConfig } from "../../src/config.js";
+import { MusubiClient } from "../../src/musubi/client.js";
+import type { FetchLike } from "../../src/musubi/types.js";
+import { createSearchTool } from "../../src/tools/search.js";
+
+function makeConfig(overrides: Partial<MusubiConfig> = {}): MusubiConfig {
+  return {
+    core: { baseUrl: "https://musubi.test", token: "t", ...(overrides.core ?? {}) },
+    presence: { defaultId: "eric/openclaw", ...(overrides.presence ?? {}) },
+  };
+}
+
+type ScriptedResponse = { status: number; body?: unknown } | { throw: Error };
+
+function createMockFetch(script: ScriptedResponse[]) {
+  const calls: Array<{ url: string; body: string | undefined }> = [];
+  let cursor = 0;
+  const fetch: FetchLike = async (url, init) => {
+    calls.push({ url, body: typeof init.body === "string" ? init.body : undefined });
+    const def = script[cursor] ?? script[script.length - 1];
+    cursor += 1;
+    if (def === undefined) throw new Error("script exhausted");
+    if ("throw" in def) throw def.throw;
+    return new Response(def.body !== undefined ? JSON.stringify(def.body) : null, {
+      status: def.status,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return { fetch, calls };
+}
+
+function makeClient(fetch: FetchLike) {
+  return new MusubiClient({
+    baseUrl: "https://musubi.test",
+    token: "t",
+    fetch,
+    sleep: async () => undefined,
+    random: () => 0,
+    generateRequestId: () => "r",
+    generateIdempotencyKey: () => "i",
+    retry: { maxAttempts: 1 },
+  });
+}
+
+describe("createSearchTool — canonical musubi_search", () => {
+  it("registers as the canonical name musubi_search", () => {
+    const { fetch } = createMockFetch([{ status: 200, body: { results: [] } }]);
+    const tool = createSearchTool({ client: makeClient(fetch), config: makeConfig() });
+    expect(tool.recommendedOptional).toBe(true);
+    expect(tool.definition.name).toBe("musubi_search");
+  });
+
+  it("invokes /v1/retrieve with mode=deep and the caller's query", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: { results: [] } }]);
+    const tool = createSearchTool({ client: makeClient(fetch), config: makeConfig() });
+
+    await tool.definition.execute("call-1", { query: "find the thing" });
+
+    expect(calls[0]?.url).toBe("https://musubi.test/v1/retrieve");
+    const body = JSON.parse(calls[0]!.body!);
+    expect(body.mode).toBe("deep");
+    expect(body.query_text).toBe("find the thing");
+  });
+
+  it("respects the planes filter when caller restricts", async () => {
+    const { fetch, calls } = createMockFetch([{ status: 200, body: { results: [] } }]);
+    const tool = createSearchTool({ client: makeClient(fetch), config: makeConfig() });
+
+    await tool.definition.execute("c1", { query: "x", planes: ["curated"], limit: 3 });
+    for (const call of calls) {
+      const body = JSON.parse(call.body!);
+      expect(body.planes).toEqual(["curated"]);
+      expect(body.limit).toBe(3);
+    }
+  });
+
+  it("renders results with [plane], score, and content", async () => {
+    const { fetch } = createMockFetch([
+      {
+        status: 200,
+        body: {
+          results: [
+            {
+              object_id: "k-1",
+              score: 0.88,
+              plane: "curated",
+              content: "Eric prefers TypeScript.",
+              namespace: "eric/_shared/curated",
+            },
+          ],
+        },
+      },
+    ]);
+    const tool = createSearchTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("call", { query: "preference" });
+
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0]!.text;
+    expect(text).toContain("[curated]");
+    expect(text).toContain("0.88");
+    expect(text).toContain("Eric prefers TypeScript.");
+  });
+
+  it("surfaces backend error as a tool error string", async () => {
+    const { fetch } = createMockFetch([{ throw: new TypeError("fetch failed") }]);
+    const tool = createSearchTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("call", { query: "x" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("Musubi search failed");
+  });
+
+  it("returns a clear no-results message when the query matches nothing", async () => {
+    const { fetch } = createMockFetch([{ status: 200, body: { results: [] } }]);
+    const tool = createSearchTool({ client: makeClient(fetch), config: makeConfig() });
+
+    const result = await tool.definition.execute("c", { query: "nothing matches" });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]?.text).toContain("No Musubi results");
+  });
+});


### PR DESCRIPTION
Closes ericmey/musubi#287.

## Stacked PR note

Base is `feat/musubi-get-tool` (PR #24, the in-flight `musubi_get` PR). When #24 merges, GitHub auto-retargets this PR to `main`.

## Summary

Brings the openclaw-musubi plugin onto the **canonical agent-tools surface** ([Musubi spec](https://github.com/ericmey/musubi/blob/main/docs/Musubi/07-interfaces/agent-tools.md), backed by [ADR 0032](https://github.com/ericmey/musubi/blob/main/docs/Musubi/13-decisions/0032-agent-tools-canonical-surface.md)). After this PR, Aoi-on-OpenClaw, Aoi-on-LiveKit-voice, and Aoi-via-Claude-Code-MCP all expose the same five tool names and shapes — closing the cross-modal continuity gap.

## Tools after this PR

| Tool | Status | Notes |
|---|---|---|
| `musubi_recent` | **new** | Recency-anchored episodic, no query. Presence-scoped today; cross-modal lights up when Musubi `slice-retrieve-recent` (#288) and the wildcards primitive ship. |
| `musubi_search` | **new (canonical name)** | Was `musubi_recall`. Body unchanged. |
| `musubi_get` | unchanged | Already canonical (lands in PR #24, this PR builds on that branch). |
| `musubi_remember` | unchanged | Already canonical. |
| `musubi_think` | unchanged | Already canonical. |
| `musubi_recall` | **deprecated alias** | One-release deprecation. Forwards to `musubi_search` with `logger.warn(...)` per call. Drops in the next minor release. |

## Implementation notes

- `src/tools/search.ts` holds the canonical body. Exports `executeSearch(...)` so the recall alias reuses it identically — no parameter or response drift between canonical and alias.
- `src/tools/recall.ts` is now a 60-line deprecation alias. Logs through the plugin host's structured-log channel (`api.logger.warn` wired in bootstrap) or falls back to `console.warn` if a wiring is missing — so a forgotten wiring still emits a visible signal.
- `src/tools/recent.ts` paginates `GET /v1/episodic?namespace=…&limit=…` and sorts client-side by event timestamp (event_at → created_at → ingested_at → created_epoch). Tag and `since` filters apply post-fetch.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 157 pass, 5 pre-existing skips. **16 new tests** (6 `search.test.ts` + 9 `recent.test.ts` + 1 deprecation log path in `recall.test.ts`).
- [x] Bootstrap integration test asserts the new six-tool registration order.

## Docs touched

- `README.md` — top-level tool list updated to canonical surface + alias note
- `docs/architecture/overview.md` — section 4 retitled "Canonical agent-tools surface"
- `docs/architecture/wiring.md` — registration trace shows search/recent/get/remember/think/recall
- `docs/decisions/0001-sidecar-with-authority.md` — capability bullet updated
- `docs/api-contract.md` — read-path expectations document `musubi_search`/`musubi_recent` and the temporary fallback path for recent

## Follow-up

After PR #24 merges and this PR rebases onto main:
1. Operator deploys the updated plugin to OpenClaw → Aoi has the canonical surface
2. When Musubi `slice-retrieve-recent` ships, follow-up PR upgrades `recent.ts` from the GET /v1/episodic fallback to `mode=recent` with cross-modal default
3. Next minor release: drop the `musubi_recall` alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)