### PR TITLE
feat!: prepare 1.0.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to a calendar-flavored semantic versioning scheme
 
 ## [Unreleased]
 
+### Added
+- **Stable 1.0.0 release.** Plugin contract surface, agent tool set, and configuration schema are now stable; future breaking changes will follow semver and be documented here.
+- Released to npm as [`openclaw-musubi`](https://www.npmjs.com/package/openclaw-musubi) with provenance attestation (SLSA Level 3 via npm trusted publishing OIDC).
+- Compat target lifted to OpenClaw `>=2026.5.4` — first version with the externalized-plugin gate path that recognizes our agent-tools registration when `contracts.tools` is properly declared.
+- Six canonical agent tools now declared in `openclaw.plugin.json` `contracts.tools` — `musubi_search`, `musubi_recent`, `musubi_get`, `musubi_remember`, `musubi_think`, `musubi_recall` (deprecation alias). Each `registerTool` call now passes its name explicitly so the openclaw 5.4 registry can verify the registration against the contract.
+- Repository tooling: Biome (lint + format), CodeQL workflow, Dependabot config, GitHub issue and PR templates as form-based YAML, expanded CI matrix covering Node 22 and 24, release-please for automated version PRs from conventional commits, OIDC trusted publishing.
+
+### Changed
+- Migrated from pnpm to npm. `engines.node` raised from `>=22` to `>=22.14.0` to match openclaw core.
+- Migrated from ESLint + Prettier to Biome 2.4.14 with a single `biome.json` config.
+
 ## [0.1.0] — 2026-04-22
 
 First tagged release. The plugin is loadable against OpenClaw via `definePluginEntry` and ships the full Musubi integration surface:

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@sinclair/typebox": "^0.34.49"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.10"
+    "openclaw": ">=2026.5.4"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
@@ -75,10 +75,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.4.19-beta.1"
+      "pluginApi": ">=2026.5.4"
     },
     "build": {
-      "openclawVersion": "2026.4.19-beta.1"
+      "openclawVersion": "2026.5.4"
     },
     "release": {
       "publishToClawHub": true,


### PR DESCRIPTION
## Summary
The cutover commit. Bumps version-related fields, seeds CHANGELOG, and triggers the release-please workflow on merge.

## What this changes
- `engines.node`: `">=22"` → `">=22.14.0"` (matches openclaw core's declared minimum).
- `openclaw.compat.pluginApi`: `">=2026.4.19-beta.1"` → `">=2026.5.4"`.
- `openclaw.build.openclawVersion`: `"2026.4.19-beta.1"` → `"2026.5.4"`.
- `peerDependencies.openclaw`: `">=2026.4.10"` → `">=2026.5.4"`.
- CHANGELOG: 1.0.0 stability entry at the top of `[Unreleased]` covering contract stability, npm provenance, the contracts.tools registration fix, and tooling.

## What happens after merge
1. release-please.yml fires, sees manifest `0.1.0` + this `feat!` + `BREAKING CHANGE` → opens `chore(main): release 1.0.0` PR.
2. **Add `NPM_TOKEN` to repo secrets** before merging the release PR (granular access token, scope: publish, restricted to `openclaw-musubi`).
3. **(Optional)** Create the `npm` environment for a deployment-gate confirmation.
4. Merge release PR → tag `v1.0.0` → publish.yml fires → `openclaw-musubi@1.0.0` lands on npm with provenance.

## BREAKING CHANGE
1.0.0 stable. Plugin contract surface is now stable; future breaking changes follow semver. Consumers on Node <22.14 must upgrade. Consumers on openclaw <2026.5.4 must upgrade or stay on 0.1.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)