### PR TITLE
chore: drop NODE_AUTH_TOKEN from publish.yml (OIDC supersedes it)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,5 @@ jobs:
       - run: npm run typecheck
       - run: npm test
       - run: npm run build
-      - name: Publish to npm (with provenance)
+      - name: Publish to npm (OIDC trusted publishing + provenance)
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
After the 1.0.0 trusted-publishing handoff, npm OIDC issues the publish credential via the workflow's id-token: write permission. The NPM_TOKEN repo secret is deleted; leaving `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` in publish.yml would set the env var to empty string, which can mask the OIDC auth path on some setup-node versions.

## Change
Remove the `env: NODE_AUTH_TOKEN` block from the publish step. `npm publish --provenance` with `id-token: write` is sufficient.

## Verification
- 1.0.0 publish (a few hours ago) used NPM_TOKEN bootstrap (worked).
- 1.0.1+ will use OIDC. This PR makes that path correct.

## Test plan
- [ ] CI green
- [ ] On next release tag, publish.yml fires and publishes via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)