### PR TITLE
ci: re-enable NODE_AUTH_TOKEN for 1.0.1 hotfix publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write   # required for npm trusted publishing (OIDC)
+  id-token: write
 
 jobs:
   npm-publish:
@@ -32,5 +32,7 @@ jobs:
       - run: npm run typecheck
       - run: npm test
       - run: npm run build
-      - name: Publish to npm (OIDC trusted publishing + provenance)
+      - name: Publish to npm (with provenance)
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Temporary fallback. OIDC trusted publishing fails on workflow_dispatch (404). NPM_TOKEN re-added as repo secret. Will revert to OIDC-only after 1.0.1 ships and we diagnose the OIDC+workflow_dispatch compatibility.